### PR TITLE
Skip Option missing from BasicSupport Mojo

### DIFF
--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/BasicSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/BasicSupport.java
@@ -146,6 +146,9 @@ public class BasicSupport extends AbstractLibertySupport {
 
     @Override
     protected void init() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            return;
+        }        
         super.init();
         // for backwards compatibility
         if (installDirectory == null) {


### PR DESCRIPTION
`liberty-maven-plugin:stop-server` will fail with the `error.server.home.validate` message even if the plugin is configured with `<skip>true</skip>`