### PR TITLE
Support for includes and excludes in the undeploy goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,37 +496,44 @@ The following are the parameters supported by this goal in addition to the [comm
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| appArchive | Location of an application file to be deployed. The application type can be war, ear, rar, eba, zip, or jar. | Yes |
+| appArtifact | Maven coordinates of an application to be deployed. | Yes, if appArchive is not set. |
+| appArchive | Location of an application file to be deployed. The application type can be war, ear, rar, eba, zip, or jar. | Yes, if appArtifact is not set. |
 | timeout | Maximum time to wait (in seconds) to verify that the deployment has completed successfully. The default value is 40 seconds. | No |
 
 Example:
 
-    <plugin>
-        <groupId>net.wasdev.wlp.maven.plugins</groupId>
-        <artifactId>liberty-maven-plugin</artifactId> 
-        <executions>
-            ...
-            <execution>
-                <id>deploy-app</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                    <goal>deploy</goal>
-                </goals>
-                <configuration>
-                    <appArchive>HelloWorld.war</appArchive>                        
-                </configuration>
-            </execution>
-            ...
-        </executions>
+    <!-- Single deploy of an application with the path of a file. -->
+    <execution>
+        <id>deploy-app</id>
+        <phase>post-integration-test</phase>
+        <goals>
+            <goal>deploy</goal>
+        </goals>
         <configuration>
-           <installDirectory>/opt/ibm/wlp</installDirectory>
-           <serverName>test</serverName>
-        </configuration>              
-    </plugin>
+            <appArchive>HelloWorld.war</appArchive>
+        </configuration>
+    </execution>
+
+    <!-- Single deploy of an application with maven coordinates. -->
+    <execution>
+        <id>deploy-by-appArtifact</id>
+        <phase>post-integration-test</phase>
+        <goals>
+            <goal>deploy</goal>
+        </goals>
+        <configuration>
+            <appArtifact>
+                <groupId>com.mycompany.webapp</groupId>
+                <artifactId>webapp</artifactId>
+                <version>1.0</version>
+                <type>war</type>
+            </appArtifact>
+        </configuration>
+    </execution>
 
 ##### undeploy
 ---
-Undeploy an application to a Liberty Profile server. The server instance must exist and must be running.
+Undeploy an application to a Liberty Profile server. The server instance must exist and must be running. If appArtifact or appArchive are not defined, the goal will undeploy all applications from the server.
 
 ###### Additional Parameters
 
@@ -534,33 +541,65 @@ The following are the parameters supported by this goal in addition to the [comm
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| appArchive | Name of an application to be undeployed. The application type can be war, ear, rar, eba, zip, or jar. | Yes |
+| appArtifact | Maven coordinates of an application to be undeployed. | No |
+| appArchive | Name of an application to be undeployed. The application type can be war, ear, rar, eba, zip, or jar. | No |
+| patternSet | Includes and excludes patterns of applications to be undeployed. | No |
 | timeout | Maximum time to wait (in seconds) to verify that the undeployment has completed successfully. The default value is 40 seconds. | No |
 
 Example:
 
-    <plugin>
-        <groupId>net.wasdev.wlp.maven.plugins</groupId>
-        <artifactId>liberty-maven-plugin</artifactId> 
-        <executions>
-            ...
-            <execution>
-                <id>undeploy-app</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                    <goal>undeploy</goal>
-                </goals>
-                <configuration>
-                    <appArchive>HelloWorld.war</appArchive>                        
-                </configuration>
-            </execution>
-            ...
-        </executions>
+    <!-- Single undeploy from an application file. -->
+    <execution>
+        <id>undeploy-by-appArchive</id>
+        <phase>post-integration-test</phase>
+        <goals>
+            <goal>undeploy</goal>
+        </goals>
         <configuration>
-           <installDirectory>/opt/ibm/wlp</installDirectory>
-           <serverName>test</serverName>
-        </configuration>              
-    </plugin>
+            <appArchive>HelloWorld.war</appArchive>
+        </configuration>
+    </execution>
+
+    <!-- Single undeploy from an application with maven coordinates. -->
+    <execution>
+        <id>undeploy-by-appArtifact</id>
+        <phase>post-integration-test</phase>
+        <goals>
+            <goal>undeploy</goal>
+        </goals>
+        <configuration>
+            <appArtifact>
+                <groupId>com.mycompany.webapp</groupId>
+                <artifactId>webapp</artifactId>
+                <version>1.0</version>
+                <type>war</type>
+            </appArtifact>
+        </configuration>
+    </execution>
+
+    <!-- Undeploy all. -->
+    <execution>
+        <id>undeploy-by-appArtifact</id>
+        <phase>post-integration-test</phase>
+        <goals>
+            <goal>undeploy</goal>
+        </goals>
+    </execution>
+
+    <!-- Undeploy from a patternSet. -->
+    <execution>
+        <id>undeploy-by-appArtifact</id>
+        <phase>post-integration-test</phase>
+        <goals>
+            <goal>undeploy</goal>
+        </goals>
+        <configuration>
+            <patternSet>
+                <includes>*.war</includes>
+                <excludes>webapp.war</excludes>
+            </patternSet>
+        </configuration>
+    </execution>
 
 ##### install-feature
 ---

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/UndeployAppMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014.
+ * (C) Copyright IBM Corporation 2014, 2015.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,89 +19,129 @@ import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
-
 import net.wasdev.wlp.ant.UndeployTask;
 import net.wasdev.wlp.maven.plugins.BasicSupport;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.tools.ant.types.PatternSet;
+import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
+
 /**
- * Undeploy application from liberty server
- * 
+ * Undeploy application from liberty server. If no parameters have been defined
+ * the mojo will undeploy all applications from the server.
+ *
  * @goal undeploy
- * 
- * 
  */
 public class UndeployAppMojo extends BasicSupport {
+    
     /**
-     * A file name which points to a specific module's jar | war | ear | eba | zip
-     * archive.
-     * 
+     * A file name which points to a specific module's jar | war | ear | eba |
+     * zip archive.
+     *
      * @parameter expression="${appArchive}"
      * @optional
      */
     protected String appArchive = null;
-
+    
     /**
-     * Maven coordinates of an application to undeploy. This is best listed as a dependency,
-     * in which case the version can be omitted.
-     * 
+     * Maven coordinates of an application to undeploy. This is best listed as a
+     * dependency, in which case the version can be omitted.
+     *
      * @parameter
      */
     protected ArtifactItem appArtifact;
-
+    
+    /**
+     * A set of patterns to include or exclude from the undeploy operation. If
+     * appArchive or appArtifact has been defined then this parameter will be
+     * ignored.
+     *
+     * @parameter
+     */
+    private PatternSet patternSet;
+    
     /**
      * Timeout to verify undeploy successfully, in seconds.
-     * 
+     *
      * @parameter expression="${timeout}" default-value="40"
      */
     protected int timeout = 40;
-
+    
+    /*
+     * (non-Javadoc)
+     * @see org.codehaus.mojo.pluginsupport.MojoSupport#doExecute()
+     */
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
             return;
         }
+        
         checkServerHomeExists();
         checkServerDirectoryExists();
         
-        if (appArchive != null && appArtifact != null) {
-            throw new MojoExecutionException(messages.getString("error.app.set.twice"));
+        UndeployTask undeployTask = (UndeployTask) ant
+                .createTask("antlib:net/wasdev/wlp/ant:undeploy");
+        
+        if (undeployTask == null) {
+            throw new NullPointerException("Undeploy task not found");
         }
-
-        if (appArtifact != null) {
-            Artifact artifact = getArtifact(appArtifact);
-            appArchive = artifact.getFile().getName();
-            log.info(MessageFormat.format(messages.getString("info.variable.set"), "artifact based application", appArtifact));
-        } else if (appArchive != null) {
-            File file = new File(appArchive);
-            if (file.exists()) {
-                appArchive = file.getName();
+        
+        if (appArchive != null || appArtifact != null) {
+            
+            if (appArchive != null && appArtifact != null) {
+                throw new MojoExecutionException(
+                        messages.getString("error.app.set.twice"));
             }
-            log.info(MessageFormat.format(messages.getString("info.variable.set"), "non-artifact based application", appArchive));
+            
+            if (appArtifact != null) {
+                Artifact artifact = getArtifact(appArtifact);
+                appArchive = artifact.getFile().getName();
+                
+                log.info(MessageFormat.format(
+                        messages.getString("info.variable.set"),
+                        "artifact based application", appArtifact));
+                
+            } else if (appArchive != null) {
+                File file = new File(appArchive);
+                if (file.exists()) {
+                    appArchive = file.getName();
+                }
+                
+                log.info(MessageFormat.format(
+                        messages.getString("info.variable.set"),
+                        "non-artifact based application", appArchive));
+                
+            }
+            
+            File destFile = new File(serverDirectory, "dropins/" + appArchive);
+            if (destFile == null || !destFile.exists()
+                    || destFile.isDirectory()) {
+                throw new IOException(MessageFormat.format(
+                        messages.getString("error.undeploy.app.noexist"),
+                        destFile.getCanonicalPath()));
+            }
+            
+            undeployTask.setFile(appArchive);
+            log.info(MessageFormat.format(
+                    messages.getString("info.undeploy.app"),
+                    destFile.getCanonicalPath()));
+            
+        } else if (patternSet != null && patternSet.hasPatterns(ant.getAnt())) {
+            log.info(messages.getString("info.undeploy.patternset"));
+            undeployTask.addPatternset(patternSet);
         } else {
-            throw new MojoExecutionException(MessageFormat.format(messages.getString("error.undeploy.app.set.validate"), ""));
+            log.info(messages.getString("info.undeploy.all"));
         }
-
-        File destFile = new File(serverDirectory, "dropins/" + appArchive);
-        if (destFile == null || !destFile.exists() || destFile.isDirectory()) {
-            throw new IOException(MessageFormat.format(messages.getString("error.undeploy.app.noexist"), destFile.getCanonicalPath()));
-        }
-
-        log.info(MessageFormat.format(messages.getString("info.undeploy.app"), destFile.getCanonicalPath()));
-        UndeployTask undeployTask = (UndeployTask) ant.createTask("antlib:net/wasdev/wlp/ant:undeploy");
-        if (undeployTask == null)
-            throw new NullPointerException("server task not found");
-
+        
         undeployTask.setInstallDir(installDirectory);
         undeployTask.setServerName(serverName);
         undeployTask.setUserDir(userDirectory);
         undeployTask.setOutputDir(outputDirectory);
-        undeployTask.setFile(appArchive);
+        
         // Convert from seconds to milliseconds
-        undeployTask.setTimeout(Long.toString(timeout*1000));
+        undeployTask.setTimeout(Long.toString(timeout * 1000));
         undeployTask.execute();
-
     }
 }

--- a/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
+++ b/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
@@ -269,3 +269,11 @@ error.app.set.twice.useraction=Modify configuration to set only appArchive or ap
 error.install.feature.set.validate=CWWKM2167E: The feature parameter is required for the install-feature goal.
 error.install.feature.set.validate.explanation=One or more features should be specified.
 error.install.feature.set.validate.useraction=Verify the feature attribute is specified for the install-feature goal.
+
+info.undeploy.patternset=CWWKM2168I: Undeploying application or applications from a pattern set.
+info.undeploy.patternset.explanation=One or more applications have been undeployed from the server using a set of includes or excludes.
+info.undeploy.patternset.useraction=No action is required.
+
+info.undeploy.all=CWWKM2169I: Undeploying all applications.
+info.undeploy.all.explanation=All applications in the server wil be undeployed.
+info.undeploy.all.useraction=No action is required.


### PR DESCRIPTION
README.md changes:
- Updated deploy documentation to add the appArtifact parameter and
examples.
- Updated undeploy documentation to add patternSet parameter and
examples.

MvnMessages.properties changes:
- Added a new message to use it when the undeploy is done by a pattern
set.
- Added a new message to use it when undeploy all will be execute it.

UndeployAppMojo changes:
- Organized imports.
- Updated mojo documentation.
- Added patternSet parameter.
- Added support for the undeploy by pattern sets.