### PR TITLE
Support for online integration tests in the liberty plugin archetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Collection of Maven plugins and archetypes for managing WebSphere Application Se
 Use Maven 2.x or 3.x to build the Liberty plugins and archetypes. 
 
 * `mvn install` : builds the plugin and the archetype. 
-* `mvn install -Poffline-its-DwlpInstallDir=<liberty_install_directory>` : builds the plugin, archetype and runs the integration tests by providing an existing installation.
-* `mvn install -Ponline-its-DwlpVersion=<liberty_version> -DwlpLicense=<liberty_license_code>` : builds the plugin, archetype and runs the integration tests by downloading a new server.
-  * Liberty versions and their respective license code can be found in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file.
+* `mvn install -Poffline-its -DwlpInstallDir=<liberty_install_directory>` : builds the plugin, archetype and runs the integration tests by providing an existing installation.
+* `mvn install -Ponline-its -DwlpVersion=<liberty_version> -DwlpLicense=<liberty_license_code>` : builds the plugin, archetype and runs the integration tests by downloading a new server.
+  * Liberty versions and their respective link to the license code can be found in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file. You can obtain the license code by reading the current license and looking for the D/N: <license code> line.
 
 ## Plugins
 

--- a/liberty-plugin-archetype/pom.xml
+++ b/liberty-plugin-archetype/pom.xml
@@ -28,20 +28,135 @@
                     <artifactId>maven-archetype-plugin</artifactId>
                     <version>2.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.10</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.8</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <profiles>
         <profile>
-            <id>run-its</id>
-            <activation>
-                <property>
-                    <name>wlpInstallDir</name>
-                </property>
-            </activation>
+            <id>offline-its</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <executions>
+                            <execution>
+                                <id>generate-projects</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <cloneProjectsTo>${project.build.directory}/it/projects</cloneProjectsTo>
+                                    <goals>
+                                        <goal>org.apache.maven.plugins:maven-archetype-plugin:generate</goal>
+                                    </goals>
+                                    <pomIncludes>
+                                        <pomInclude>*</pomInclude>
+                                    </pomIncludes>
+                                    <projectsDirectory>${basedir}/src/it/projects</projectsDirectory>
+                                    <properties>
+                                        <archetypeArtifactId>${project.artifactId}</archetypeArtifactId>
+                                        <archetypeGroupId>${project.groupId}</archetypeGroupId>
+                                        <archetypeRepository>local</archetypeRepository>
+                                        <archetypeVersion>${project.version}</archetypeVersion>
+                                        <interactiveMode>false</interactiveMode>
+                                        <artifactId>myProject</artifactId>
+                                        <groupId>myGroup</groupId>
+                                        <wlpInstallDir>${wlpInstallDir}</wlpInstallDir>
+                                        <wlpPluginVersion>${project.version}</wlpPluginVersion>
+                                    </properties>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>verify-projects</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <goals>
+                                        <goal>install</goal>
+                                    </goals>
+                                    <pomIncludes>
+                                        <pomInclude>*/*/pom.xml</pomInclude>
+                                    </pomIncludes>
+                                    <projectsDirectory>${project.build.directory}/it/projects</projectsDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>online-its</id>
+            <properties>
+                <wlpInstallDir>${project.build.directory}/wlp</wlpInstallDir>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>getting-server</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <!-- This artifact is generated by the setup IT of 
+                                                the plugin's project -->
+                                            <groupId>net.wasdev.wlp.maven.it</groupId>
+                                            <artifactId>assembly-server</artifactId>
+                                            <version>1.0-SNAPSHOT</version>
+                                            <type>zip</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <overWrite>yes</overWrite>
+                                    <outputDirectory>${wlpInstallDir}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>setting-file-permissions-if-necessary</id>
+                                <phase>process-sources</phase>
+                                <configuration>
+                                    <target>
+                                        <chmod perm="+x" verbose="true">
+                                            <fileset dir="${wlpInstallDir}/bin">
+                                                <exclude name="*.bat"/>
+                                                <exclude name="/tools/*.*"/>
+                                            </fileset>
+                                        </chmod>
+                                      </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>


### PR DESCRIPTION
This change adds support to execute integration tests in online/offline
mode by downloading a wlp or specifying an existing installation for the archetype project.