### PR TITLE
Support installing Liberty from zip files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: java
 jdk:
+  - oraclejdk7
   - oraclejdk8
 script: 
-  - "mvn verify -Ponline-its -DwlpVersion=8.5.5_06 -DwlpLicense=L-MCAO-9SYMVC"
+  - travis_wait mvn verify -Ponline-its -Dinvoker.streamLogs=true -DwlpVersion=8.5.5_07 -DwlpLicense=L-MCAO-9SYMVC

--- a/README.md
+++ b/README.md
@@ -136,30 +136,44 @@ Use the `assemblyArtifact` parameter to specify the name of the Maven artifact t
 
 Use the `install` parameter to download and install Liberty profile server from the [Liberty repository](https://developer.ibm.com/wasdev/downloads/) or other location.
 
-The Liberty license code must always be specified in order to install the Liberty server. If you are installing Liberty from the Liberty repository, you can obtain the license code by reading the [current license](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.5/lafiles/runtime/en.html) and looking for the `D/N: <license code>` line. Otherwise, download the Liberty runtime archive and execute `java -jar wlp*runtime.jar --viewLicenseInfo` command and look for the `D/N: <license code>` line.
+In certain cases, the Liberty license code may need to be provided in order to install the runtime. If the license code is required and if you are installing Liberty from the Liberty repository, you can obtain the license code by reading the [current license](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.7/lafiles/runtime/en.html) and looking for the `D/N: <license code>` line. Otherwise, download the Liberty runtime archive and execute `java -jar wlp*runtime.jar --viewLicenseInfo` command and look for the `D/N: <license code>` line.
 
-* Install using the Liberty repository. The plugin will use the Liberty repository to find the Liberty runtime archive to install based on the given version.
+* Install using the Liberty repository. The plugin will use the Liberty repository to find the Liberty runtime archive to install based on the given version and type. In this case, install Liberty runtime with Java EE 7 Web Profile features.
  ```xml
     <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
         <configuration>
             <install>
+                <type>webProfile7</type>
+            </install>
+        </configuration>
+    </plugin>
+ ```
+
+* Same as above but install Liberty runtime with Java EE 6 Web Profile features (must provide `licenseCode`).
+ ```xml
+    <plugin>
+        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+        <artifactId>liberty-maven-plugin</artifactId>
+        <configuration>
+            <install>
+                <type>webProfile6</type>
                 <licenseCode><license code></licenseCode>
             </install>
         </configuration>
     </plugin>
  ```
 
-* Install from a given location. The `runtimeUrl` sub-parameter specifies a location of the Liberty runtime archive file to install.
+* Install from a given location. The `runtimeUrl` sub-parameter specifies a location of the Liberty profile's runtime `.jar` or `.zip` file to install. The `licenseCode` is only needed when installing from `.jar` file.
  ```xml
     <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
         <configuration>
             <install>
+                <runtimeUrl><url to .jar or .zip file></runtimeUrl>
                 <licenseCode><license code></licenseCode>
-                <runtimeUrl><url to runtime.jar></runtimeUrl>
             </install>
         </configuration>
     </plugin>
@@ -169,9 +183,10 @@ The `install` parameter has the following sub-parameters:
 
 | Name | Description | Required |
 | --------  | ----------- | -------  |
-| licenseCode | Liberty profile license code. See [above](#install-from-repository). | Yes |
+| licenseCode | Liberty profile license code. See [above](#install-from-repository). | Yes, if `type` is `webProfile6` or `runtimeUrl` specifies a `.jar` file. |
 | version | Exact or wildcard version of the Liberty profile server to install. Available versions are listed in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file. Only used if `runtimeUrl` is not set. The default value is `8.5.+`. | No |
-| runtimeUrl | URL to the Liberty profile's `wlp*runtime.jar`. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
+| type | Liberty runtime type to download from the Liberty repository. Currently, the following types are supported: `kernel`, `webProfile6`, `webProfile7`, and `javaee7`. Only used if `runtimeUrl` is not set. The default value is `webProfile6`. | No |
+| runtimeUrl | URL to the Liberty profile's runtime `.jar` or a `.zip` file. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
 | cacheDirectory | The directory used for caching downloaded files such as the license or `.jar` files. The default value is `${settings.localRepository}/wlp-cache`. | No |
 | username | Username needed for basic authentication. | No |
 | password | Password needed for basic authentication. | No |

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/BasicSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/BasicSupport.java
@@ -347,6 +347,7 @@ public class BasicSupport extends AbstractLibertySupport {
         installTask.setRuntimeUrl(install.getRuntimeUrl());
         installTask.setVerbose(install.isVerbose());
         installTask.setMaxDownloadTime(install.getMaxDownloadTime());
+        installTask.setType(install.getType());
         installTask.setOffline(settings.isOffline());
         
         String cacheDir = install.getCacheDirectory();

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/Install.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/Install.java
@@ -16,7 +16,7 @@
 package net.wasdev.wlp.maven.plugins;
 
 public class Install {
-    
+
     private String cacheDirectory;
     private boolean verbose;
     private String licenseCode;
@@ -26,11 +26,12 @@ public class Install {
     private String password;
     private long maxDownloadTime;
     private String serverId;
-    
+    private String type;
+
     public String getCacheDirectory() {
         return cacheDirectory;
     }
-    
+
     public void setCacheDirectory(String cacheDirectory) {
         this.cacheDirectory = cacheDirectory;
     }
@@ -38,23 +39,23 @@ public class Install {
     public String getLicenseCode() {
         return licenseCode;
     }
-    
+
     public void setLicenseCode(String licenseCode) {
         this.licenseCode = licenseCode;
     }
-    
+
     public String getVersion() {
         return version;
     }
-    
+
     public void setVersion(String version) {
         this.version = version;
     }
-    
+
     public String getRuntimeUrl() {
         return runtimeUrl;
     }
-    
+
     public void setRuntimeUrl(String runtimeUrl) {
         this.runtimeUrl = runtimeUrl;
     }
@@ -62,11 +63,11 @@ public class Install {
     public boolean isVerbose() {
         return verbose;
     }
-    
+
     public void setVerbose(boolean verbose) {
         this.verbose = verbose;
     }
-    
+
     public String getUsername() {
         return username;
     }
@@ -97,5 +98,13 @@ public class Install {
 
     public void setServerId(String serverId) {
         this.serverId = serverId;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 }


### PR DESCRIPTION
Support install Liberty runtime from the Liberty repository using .zip files. 
Also, update Travis to run tests on Oracle Java 7 and log output from tests