### PR TITLE
#34: Os parameter added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,8 @@ The following are the parameters supported by this goal in addition to the [comm
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
 | packageFile | Location of the target file or directory. If the target location is a file, the contents of the server instance will be compressed into the specified file. If the target location is a directory, the contents of the server instance will be compressed into `${packageFile}/${serverName}.zip` file. If the target location is not specified, it defaults to `${installDirectory}/usr/servers/${serverName}.zip` if `installDirectory` is set. Otherwise, it defaults to `${assemblyInstallDirectory}/usr/servers/${serverName}.zip` if `assemblyArchive` or `assemblyArtifact` is set. | No |
-| include | Packaging type. One of `all`, `usr`, or `minify`. The default value is `all`. | No |
+| include | Packaging type. One of `all`, `usr`, or `minify`. The default value is `all`. | Yes, only when os parameter is set |
+| os | A comma-delimited list of operating systems that you want the packaged server to support. To specify that an operating system is not to be supported, prefix it with a minus sign ("-"). The 'include' attribute must be set to 'minify'. | No |
 
 Example:
 ```xml
@@ -411,6 +412,8 @@ Example:
             </goals>
             <configuration>
                 <packageFile>${project.build.directory}/test.zip</packageFile>
+                <include>minify</include>
+                <os>OS/400,-z/OS</os>
             </configuration>
         </execution>
         ...

--- a/liberty-maven-plugin/src/it/tests/basic-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/basic-it/pom.xml
@@ -149,6 +149,8 @@
                         </goals>
                         <configuration>
                             <packageFile>${project.build.directory}</packageFile>
+			                <include>minify</include>
+			                <os>Windows8</os>
                         </configuration>
                     </execution>
                 </executions>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
@@ -44,6 +44,13 @@ public class PackageServerMojo extends StartDebugMojoSupport {
      * @parameter expression="${include}"
      */
     private String include;
+
+    /**
+     * Support for specific OS. Comma-delimited list of values.
+     * 
+     * @parameter expression="${os}"
+     */
+    private String os;
     
     /**
      * @parameter
@@ -76,6 +83,7 @@ public class PackageServerMojo extends StartDebugMojoSupport {
         }
         serverTask.setArchive(packageFile);
         serverTask.setInclude(include);
+        serverTask.setOs(os);
         log.info(MessageFormat.format(messages.getString("info.server.package.file.location"), packageFile.getCanonicalPath()));
         serverTask.execute();
 


### PR DESCRIPTION
Ready for the ci.ant 1.1 release (https://github.com/WASdev/ci.ant/pull/37)

Changes:
<ul>
<li>Changed the 'Required' field of include parameter to <i>Yes, only when the `os` option is set</i> in README.md.</li>
<li>Added the os attribute to the server task parameters table in README.md.</li>
<li>Added an integration test for the os package.</li>
<li>Added the os attribute to PackageServerMojo and its inclusion in the doExecute method.</li>
</ul>
