### PR TITLE
Os parameter added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,8 @@ The following are the parameters supported by this goal in addition to the [comm
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
 | packageFile | Location of the target file or directory. If the target location is a file, the contents of the server instance will be compressed into the specified file. If the target location is a directory, the contents of the server instance will be compressed into `${packageFile}/${serverName}.zip` file. If the target location is not specified, it defaults to `${installDirectory}/usr/servers/${serverName}.zip` if `installDirectory` is set. Otherwise, it defaults to `${assemblyInstallDirectory}/usr/servers/${serverName}.zip` if `assemblyArchive` or `assemblyArtifact` is set. | No |
-| include | Packaging type. One of `all`, `usr`, or `minify`. The default value is `all`. | No |
+| include | Packaging type. One of `all`, `usr`, or `minify`. The default value is `all`. | Yes, only when the `os` option is set |
+| os | A comma-delimited list of operating systems that you want the packaged server to support. To specify that an operating system is not to be supported, prefix it with a minus sign ("-"). The 'include' attribute __must__ be set to 'minify'. | No |
 
 Example:
 ```xml

--- a/liberty-maven-plugin/src/it/tests/basic-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/basic-it/pom.xml
@@ -149,6 +149,8 @@
                         </goals>
                         <configuration>
                             <packageFile>${project.build.directory}</packageFile>
+                            <include>minify</include>
+                            <os>Windows7,Windows8</os>
                         </configuration>
                     </execution>
                 </executions>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
@@ -44,6 +44,21 @@ public class PackageServerMojo extends StartDebugMojoSupport {
      * @parameter expression="${include}"
      */
     private String include;
+
+    /**
+     * Os supported. Specifies the operating systems that you want the packaged server to support. 
+     *     Supply a comma-separated list. The default value is any, indicating that the server is to 
+     *     be deployable to any operating system supported by the source. To specify that an operating 
+     *     system is not to be supported, prefix it with a minus sign ("-"). For a list of operating system 
+     *     values, refer to the OSGi Alliance web site at the following URL: 
+     *     http://www.osgi.org/Specifications/Reference#os. 
+     *     This option applies only to the package operation, and can be used only with the 
+     *     --include=minify option. If you exclude an operating system, you cannot later include it if you 
+     *     repeat the minify operation on the archive.
+     * 
+     * @parameter expression="${os}"
+     */
+    private String os;
     
     /**
      * @parameter
@@ -76,6 +91,7 @@ public class PackageServerMojo extends StartDebugMojoSupport {
         }
         serverTask.setArchive(packageFile);
         serverTask.setInclude(include);
+        serverTask.setOs(os);
         log.info(MessageFormat.format(messages.getString("info.server.package.file.location"), packageFile.getCanonicalPath()));
         serverTask.execute();
 


### PR DESCRIPTION
Fixed issue 34 (https://github.com/WASdev/ci.maven/issues/34).

Changes to README.md:
<ul>
<li>Changed the 'Required' field of <i>include</i> parameter to <b>Yes, only when the `os` option is set</b>.</li>
<li>Added the <i>os</i> attribute to the package-server goal parameters table.</li>
</ul>
Changes to  liberty-maven-plugin/src/it/tests/basic-it/pom.xmll:
<ul>
<li>Added the <i>include</i> and <i>os</i> parameters to perform a os-package server.</li>
</ul>
Changes to PackageServerMojo.java:
<ul>
<li>Added the <i>os</i> attribute and its description from https://www-01.ibm.com/support/knowledgecenter/was_beta_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/rwlp_command_server.html.</li>
<li>Added the <i>os</i> parameter to the <i>serverTask</i> with the <i>setOs()</i> method.</li>
</ul>
