### PR TITLE
Install Liberty from the Liberty repository by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ If you are using a snapshot version of `liberty-maven-plugin` then you will also
 
 ##### Liberty installation configuration
 
-`liberty-maven-plugin` must first be configured with Liberty profile installation information. The installation information can be specified as an existing installation directory, a packaged server, or as a Maven artifact. The `liberty-maven-plugin` can also download and install Liberty profile server from the [Liberty repository](https://developer.ibm.com/wasdev/downloads/) or other location.
+`liberty-maven-plugin` must first be configured with Liberty profile installation information. The installation information can be specified as an existing installation directory, a packaged server, or as a Maven artifact. The `liberty-maven-plugin` can also download and install Liberty profile server from the [Liberty repository](https://developer.ibm.com/wasdev/downloads/) or other location. 
+By default, the plugin will install Liberty runtime with the Java EE 7 Web Profile features from the Liberty repository.
 
 ###### Using an existing installation
 
@@ -139,20 +140,15 @@ Use the `install` parameter to download and install Liberty profile server from 
 
 In certain cases, the Liberty license code may need to be provided in order to install the runtime. If the license code is required and if you are installing Liberty from the Liberty repository, you can obtain the license code by reading the [current license](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/8.5.5.7/lafiles/runtime/en.html) and looking for the `D/N: <license code>` line. Otherwise, download the Liberty runtime archive and execute `java -jar wlp*runtime.jar --viewLicenseInfo` command and look for the `D/N: <license code>` line.
 
-* Install using the Liberty repository. The plugin will use the Liberty repository to find the Liberty runtime archive to install based on the given version and type. In this case, install Liberty runtime with Java EE 7 Web Profile features.
+* Install from the Liberty repository. The plugin will use the Liberty repository to find the Liberty runtime archive to install based on the given version and type. This is the default installation method - no extra configuration is required. By default, the latest Liberty runtime with the Java EE 7 Web Profile features will be installed.
  ```xml
     <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <configuration>
-            <install>
-                <type>webProfile7</type>
-            </install>
-        </configuration>
     </plugin>
  ```
 
-* Same as above but install Liberty runtime with Java EE 6 Web Profile features (must provide `licenseCode`).
+* Install Liberty runtime with Java EE 6 Web Profile features from the Liberty repository (must provide `licenseCode`).
  ```xml
     <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -186,7 +182,7 @@ The `install` parameter has the following sub-parameters:
 | --------  | ----------- | -------  |
 | licenseCode | Liberty profile license code. See [above](#install-from-repository). | Yes, if `type` is `webProfile6` or `runtimeUrl` specifies a `.jar` file. |
 | version | Exact or wildcard version of the Liberty profile server to install. Available versions are listed in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file. Only used if `runtimeUrl` is not set. The default value is `8.5.+`. | No |
-| type | Liberty runtime type to download from the Liberty repository. Currently, the following types are supported: `kernel`, `webProfile6`, `webProfile7`, and `javaee7`. Only used if `runtimeUrl` is not set. The default value is `webProfile6`. | No |
+| type | Liberty runtime type to download from the Liberty repository. Currently, the following types are supported: `kernel`, `webProfile6`, `webProfile7`, and `javaee7`. Only used if `runtimeUrl` is not set. Defaults to `webProfile6` if `licenseCode` is set and `webProfile7` otherwise. | No |
 | runtimeUrl | URL to the Liberty profile's runtime `.jar` or a `.zip` file. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
 | cacheDirectory | The directory used for caching downloaded files such as the license or `.jar` files. The default value is `${settings.localRepository}/wlp-cache`. | No |
 | username | Username needed for basic authentication. | No |

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/BasicSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/BasicSupport.java
@@ -184,12 +184,13 @@ public class BasicSupport extends AbstractLibertySupport {
                 installType = InstallType.FROM_FILE;
                 installDirectory = checkServerHome(assemblyArchive);
                 log.info(MessageFormat.format(messages.getString("info.variable.set"), "installDirectory", installDirectory));
-            } else if (install != null) {
+            } else {
+                if (install == null) {
+                    install = new Install();
+                }
                 installType = InstallType.FROM_ARCHIVE;
                 installDirectory = new File(assemblyInstallDirectory, "wlp");
                 log.info(MessageFormat.format(messages.getString("info.variable.set"), "installDirectory", installDirectory));
-            } else {
-                throw new MojoExecutionException("Liberty profile installation option is not set."); 
             }
 
             // set server name


### PR DESCRIPTION
No need to configure installation information by default.
