### PR TITLE
A number of archetype improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ Example:
 
 ### liberty-plugin-archetype
 
-`liberty-plugin-archetype` is used to generate a basic multi-module project that builds a simple web application, deploys and tests it on the Liberty Profile server. It also creates a Liberty Profile server package that includes the application.
+`liberty-plugin-archetype` is used to generate a basic multi-module project that builds a simple web application, deploys and tests it on the Liberty profile server. It also creates a Liberty profile server package that includes the application.
 
 #### Usage
 
@@ -821,8 +821,7 @@ Example:
         -DarchetypeArtifactId=liberty-plugin-archetype \
         -DgroupId=test \
         -DartifactId=test \
-        -Dversion=1.0-SNAPSHOT \
-        -DwlpInstallDir=<liberty_install_directory>
+        -Dversion=1.0-SNAPSHOT
 
 ## IBM DHE repository
 

--- a/liberty-plugin-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/liberty-plugin-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -5,7 +5,6 @@
     xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <requiredProperties>
-        <requiredProperty key="wlpInstallDir"/>
         <requiredProperty key="wlpPluginVersion">
           <defaultValue>1.0</defaultValue>
         </requiredProperty>
@@ -27,7 +26,7 @@
                 </fileSet>
             </fileSets>
         </module>
-        
+
         <module id="${rootArtifactId}-test" dir="__rootArtifactId__-test" name="${rootArtifactId}-test">
             <fileSets>
                 <fileSet filtered="true" packaged="true" encoding="UTF-8">
@@ -56,6 +55,6 @@
                     </includes>
                 </fileSet>
             </fileSets>
-        </module>        
+        </module>
     </modules>
 </archetype-descriptor>

--- a/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-assembly/pom.xml
+++ b/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-assembly/pom.xml
@@ -8,7 +8,7 @@
         <artifactId>${rootArtifactId}-parent</artifactId>
         <version>${version}</version>
     </parent>
-    
+
     <artifactId>${rootArtifactId}-assembly</artifactId>
     <name>Simple Web Application Server Assembly</name>
     <packaging>liberty-assembly</packaging>
@@ -29,10 +29,13 @@
                 <artifactId>liberty-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <installDirectory>${wlp.install.dir}</installDirectory>  
+                    <installDirectory>${wlp.install.dir}</installDirectory>
+                    <userDirectory>${project.build.directory}</userDirectory>
                     <serverName>production</serverName>
                     <!-- Use custom server.xml -->
                     <configFile>${project.basedir}/src/test/resources/wlp/server.xml</configFile>
+                    <!-- Drop application into apps/ directory -->
+                    <appsDirectory>apps</appsDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-assembly/src/test/resources/wlp/server.xml
+++ b/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-assembly/src/test/resources/wlp/server.xml
@@ -2,12 +2,14 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>servlet-3.0</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <httpEndpoint id="defaultHttpEndpoint"
                   host="localhost"
                   httpPort="8080"
                   httpsPort="8443" />
+
+    <application location="${rootArtifactId}-web-${version}.war" />
 
 </server>

--- a/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-test/pom.xml
+++ b/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-test/pom.xml
@@ -43,7 +43,6 @@
         </testResources>
 
         <plugins>
-            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -67,7 +66,31 @@
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <executions>
-                    <!-- Start server with a custom server.xml -->
+                    <!-- Create server with custom server.xml -->
+                    <execution>
+                        <id>create-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>create-server</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Use server.xml from target/ directory with variables replaced -->
+                            <configFile>${project.build.testOutputDirectory}/wlp/server.xml</configFile>
+                        </configuration>
+                    </execution>
+                    <!-- Install application in <dependencies/> into apps/ directory -->
+                    <execution>
+                        <id>install-apps</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install-apps</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Drop application into apps/ directory -->
+                            <appsDirectory>apps</appsDirectory>
+                        </configuration>
+                    </execution>
+                    <!-- Start the server -->
                     <execution>
                         <id>start-liberty-server</id>
                         <phase>pre-integration-test</phase>
@@ -76,38 +99,6 @@
                         </goals>
                         <configuration>
                             <verifyTimeout>40</verifyTimeout>
-                            <!-- Use server.xml from target/ directory with variables replaced -->
-                            <configFile>${project.build.testOutputDirectory}/wlp/server.xml</configFile>
-                        </configuration>
-                    </execution>
-                    <!-- Deploy the generated war file -->
-                    <execution>
-                        <id>deploy web application</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>deploy</goal>
-                        </goals>
-                        <configuration>
-                            <appArtifact>
-                                <groupId>${groupId}</groupId>
-                                <artifactId>${rootArtifactId}-web</artifactId>
-                                <type>war</type>
-                            </appArtifact>
-                        </configuration>
-                    </execution>
-                    <!-- Undeploy the war file -->
-                    <execution>
-                        <id>undeploy web application</id>
-                        <phase>post-integration-test</phase>
-                        <goals>
-                            <goal>undeploy</goal>
-                        </goals>
-                        <configuration>
-                            <appArtifact>
-                                <groupId>${groupId}</groupId>
-                                <artifactId>${rootArtifactId}-web</artifactId>
-                                <type>war</type>
-                            </appArtifact>                        
                         </configuration>
                     </execution>
                     <!-- Stop the server -->
@@ -121,6 +112,7 @@
                 </executions>
                 <configuration>
                     <installDirectory>${wlp.install.dir}</installDirectory>
+                    <userDirectory>${project.build.directory}</userDirectory>
                     <serverName>test</serverName>
                 </configuration>
             </plugin>

--- a/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-test/src/test/resources/wlp/server.xml
+++ b/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-test/src/test/resources/wlp/server.xml
@@ -2,12 +2,14 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>servlet-3.0</feature>
+        <feature>servlet-3.1</feature>
     </featureManager>
 
     <httpEndpoint id="defaultHttpEndpoint"
                   host="localhost"
                   httpPort="${httpPort}"
                   httpsPort="${httpsPort}" />
+
+    <application location="${rootArtifactId}-web-${version}.war" />
 
 </server>

--- a/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-web/pom.xml
+++ b/liberty-plugin-archetype/src/main/resources/archetype-resources/__rootArtifactId__-web/pom.xml
@@ -8,15 +8,15 @@
         <artifactId>${rootArtifactId}-parent</artifactId>
         <version>${version}</version>
     </parent>
-    
+
     <artifactId>${rootArtifactId}-web</artifactId>
     <name>Simple Web Application</name>
     <packaging>war</packaging>
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-servlet_3.0_spec</artifactId>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/liberty-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/liberty-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -10,9 +10,6 @@
     <version>${version}</version>
 
     <properties>
-        <!-- Specify Liberty profile server installation directory -->
-        <wlp.install.dir>${wlpInstallDir}</wlp.install.dir>
-        
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -31,9 +28,9 @@
                 <version>3.1</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.geronimo.specs</groupId>
-                <artifactId>geronimo-servlet_3.0_spec</artifactId>
-                <version>1.0</version>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.1.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -58,7 +55,7 @@
                         <source>1.6</source>
                         <target>1.6</target>
                     </configuration>
-                </plugin>             
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
@@ -107,6 +104,51 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>default-liberty</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <wlp.install.dir>../target/wlp</wlp.install.dir>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>install-server</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                          <assemblyInstallDirectory>${project.build.directory}</assemblyInstallDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+       </profile>
+
+       <profile>
+            <id>custom-liberty</id>
+            <activation>
+                <property>
+                    <name>wlpInstallDir</name>
+                </property>
+            </activation>
+            <properties>
+                <wlp.install.dir>${wlpInstallDir}</wlp.install.dir>
+            </properties>
+       </profile>
+
+   </profiles>
 
     <modules>
         <module>${artifactId}-web</module>


### PR DESCRIPTION
* By default, download and install Liberty webProfile7 runtime (no need to pass `wlpInstallDir` anymore).
* Update dependencies and Liberty features to servlet 3.1.
* In the test module, copy the application into `apps` directory instead of deploying/undeploy the application from the `dropins` directory. 
* In the assembly module, copy the application into `apps` directory.