### PR TITLE
Enhance install feature to installutility capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,19 +683,23 @@ Examples:
 ---
 Install a feature packaged as a Subsystem Archive (esa) to the Liberty runtime.
 
+To install the missing features declared in the `server.xml` file, don't specify any `feature` names in the `features` configuration (You still need to specify the `acceptLicense` parameter).
+
 ###### Additional Parameters
 
 The following are the parameters supported by this goal in addition to the [common parameters](#common-parameters).
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| feature | Specify the location of the Subsystem archive to be used. This can be an esa file, an IBM-Shortname or a Subsystem-SymbolicName of the Subsystem archive. The value can be a file name or a URL to the esa file. | Yes |
+| feature | Specify the location of the Subsystem archive to be used. This can be an esa file, an IBM-Shortname or a Subsystem-SymbolicName of the Subsystem archive. The value can be a file name or a URL to the esa file. | No |
 | acceptLicense | Automatically indicate acceptance of license terms and conditions. | No |
 | to | Specify where to install the feature. The feature can be installed to any configured product extension location, or as a user feature (usr, extension). If this option is not specified the feature will be installed as a user feature. | No |
-| whenFileExists |  If a file that is part of the esa already exists on the system, you must specify what actions to take. Valid options are: `fail` - abort the installation; `ignore` - continue the installation and ignore the file that exists; `replace` - overwrite the existing file. | No |
+| from | Specifies a single directory-based repository as the source of the assets. | No |
 
-Example:
-```xml
+Examples:
+
+1. Install specific features.
+ ```xml
 <plugin>
     <groupId>net.wasdev.wlp.maven.plugins</groupId>
     <artifactId>liberty-maven-plugin</artifactId>
@@ -722,7 +726,35 @@ Example:
        <serverName>test</serverName>
     </configuration>
 </plugin>
-```
+ ```
+
+2. Check the server.xml file and install the missing features.
+ ```xml
+<plugin>
+    <groupId>net.wasdev.wlp.maven.plugins</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <executions>
+        ...
+        <execution>
+            <id>install-feature</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+                <goal>install-feature</goal>
+            </goals>
+            <configuration>
+                <features>
+                    <acceptLicense>true</acceptLicense>
+                </features>
+            </configuration>
+        </execution>
+        ...
+    </executions>
+    <configuration>
+       <installDirectory>/opt/ibm/wlp</installDirectory>
+       <serverName>test</serverName>
+    </configuration>
+</plugin>
+ ```
 
 ##### uninstall-feature
 ---

--- a/liberty-maven-plugin/src/it/tests/install-features-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/install-features-it/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.wasdev.wlp.maven.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>install-features-it</artifactId>
+    <packaging>pom</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <executions>
+                    <execution>
+                        <id>install-liberty-server</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>install-server</goal>
+                        </goals>
+                    </execution>
+                    <!-- Create the server -->
+                    <execution>
+                        <id>create-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>create-server</goal>
+                        </goals>
+                    </execution>
+                    <!-- Install the features (mongodb-2.0, oauth-2.0 & openid-2.0) using only the server name -->
+                    <execution>
+                        <id>install-server-features</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install-feature</goal>
+                        </goals>
+                        <configuration>
+                            <features>
+                                <acceptLicense>true</acceptLicense>
+                            </features>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <assemblyArtifact>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>assembly-server</artifactId>
+                        <version>${project.version}</version>
+                        <type>zip</type>
+                    </assemblyArtifact>
+                    <serverName>test</serverName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/liberty-maven-plugin/src/it/tests/install-features-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/tests/install-features-it/src/test/resources/server.xml
@@ -1,0 +1,9 @@
+<server description="default server">
+    <featureManager>    
+        <feature>wab-1.0</feature>
+        <feature>jsp-2.2</feature>
+        <feature>mongodb-2.0</feature>
+        <feature>openid-2.0</feature>
+        <feature>couchdb-1.0</feature>
+    </featureManager>     
+</server>

--- a/liberty-maven-plugin/src/it/tests/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/pom.xml
@@ -17,6 +17,7 @@
         <module>test-assembly</module>
         <module>assembly-it</module>
         <module>basic-it</module>
+        <module>install-features-it</module>
     </modules>
 
 </project>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallFeatureMojo.java
@@ -52,11 +52,6 @@ public class InstallFeatureMojo extends BasicSupport {
             return;
         }
         
-        if (features.getFeatures().size() <= 0) {
-            throw new MojoExecutionException(
-                    messages.getString("error.install.feature.set.validate"));
-        }
-
         InstallFeatureTask installFeatureTask = (InstallFeatureTask) ant
                 .createTask("antlib:net/wasdev/wlp/ant:install-feature");
 
@@ -70,8 +65,10 @@ public class InstallFeatureMojo extends BasicSupport {
         installFeatureTask.setOutputDir(outputDirectory);
         installFeatureTask.setAcceptLicense(features.isAcceptLicense());
         installFeatureTask.setTo(features.getTo());
+        // whenFileExist is deprecated, but keep it to ensure backward compatibility
         installFeatureTask.setWhenFileExists(features.getWhenFileExists());
         installFeatureTask.setFeatures(features.getFeatures());
+        installFeatureTask.setFrom(features.getFrom());
         installFeatureTask.execute();
     }
 

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/types/Features.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/types/Features.java
@@ -39,6 +39,7 @@ public class Features {
     private String to = "usr";
 
     /**
+     * @deprecated installUtility does not have a whenFileExist parameter
      * If a file that is part of the ESA already exists on the system, you must
      * specify what actions to take. Valid options are: fail - abort the
      * installation; ignore - continue the installation and ignore the file that
@@ -51,6 +52,13 @@ public class Features {
      * A list with the names of the features.
      */
     private List<Feature> featureList = new ArrayList<Feature>();
+    
+    /**
+     * A single directory-based repository as the source of the assets for the installUtility command.
+     * 
+     * @parameter expression="${from}"
+     */
+    private String from = null;
 
     public boolean isAcceptLicense() {
         return acceptLicense;
@@ -67,13 +75,27 @@ public class Features {
     public void setTo(String to) {
         this.to = to;
     }
-
+    
+    /**
+     * @deprecated installUtility does not have a whenFileExist parameter
+     */
     public String getWhenFileExists() {
         return whenFileExists;
     }
 
+    /**
+     * @deprecated installUtility does not have a whenFileExist parameter
+     */
     public void setWhenFileExists(String whenFileExists) {
         this.whenFileExists = whenFileExists;
+    }
+    
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
     }
 
     /**


### PR DESCRIPTION
Issues resolved: https://github.com/WASdev/ci.maven/issues/47 https://github.com/WASdev/ci.maven/issues/19 (Not sure)

Added the ability to install features from the server.xml file and the parameter _from_.

Changes to ../types/Features.java:
* Added the attribute _from_ along with it setter and getter.

Changes to ../InstallFeatureMojo.java:
* Removed the requirement for having features, since the install from the server.xml file uses this characteristic.
* Added a condition to avoid NullPointer exceptions.

Changes to integration tests:
* Created a module to test the install.feature goal from the server.xml.

Changes to README:
* _from_ parameter added.
* Update examples.