### PR TITLE
Added runnable option to package a server

### DIFF
--- a/docs/package-server.md
+++ b/docs/package-server.md
@@ -2,6 +2,8 @@
 ---
 Package a Liberty Profile server.
 
+To WAS Liberty 8.5.5.9 and above it is possible to package a server into a jar file using option `runnable` on `include` parameter. It creates a .jar file that include Liberty server, application and configuration. The `java -jar` command will run Liberty and the packaged application.
+
 ###### Additional Parameters
 
 The following are the parameters supported by this goal in addition to the [common server parameters](common-server-parameters.md#common-server-parameters) and the [common parameters](common-parameters.md#common-parameters).
@@ -9,10 +11,11 @@ The following are the parameters supported by this goal in addition to the [comm
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
 | packageFile | Location of the target file or directory. If the target location is a file, the contents of the server instance will be compressed into the specified file. If the target location is a directory, the contents of the server instance will be compressed into `${packageFile}/${serverName}.zip` file. If the target location is not specified, it defaults to `${installDirectory}/usr/servers/${serverName}.zip` if `installDirectory` is set. Otherwise, it defaults to `${assemblyInstallDirectory}/usr/servers/${serverName}.zip` if `assemblyArchive` or `assemblyArtifact` is set. | No |
-| include | Packaging type. One of `all`, `usr`, or `minify`. The default value is `all`. | Yes, only when the `os` option is set |
+| include | Packaging type. One of `all`, `usr`, `minify` or `runnable` (8.5.5.9 and above). The default value is `all`. | Yes, only when the `os` option is set |
 | os | A comma-delimited list of operating systems that you want the packaged server to support. To specify that an operating system is not to be supported, prefix it with a minus sign ("-"). The 'include' attribute __must__ be set to 'minify'. | No |
 
-Example:
+Examples:
+1. Package test server into a zip file.
 ```xml
 <plugin>
     <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -27,6 +30,33 @@ Example:
             </goals>
             <configuration>
                 <packageFile>${project.build.directory}/test.zip</packageFile>
+            </configuration>
+        </execution>
+        ...
+    </executions>
+    <configuration>
+       <installDirectory>/opt/ibm/wlp</installDirectory>
+       <serverName>test</serverName>
+    </configuration>
+</plugin>
+```
+
+2. Package test server into a runnable jar file. 
+```xml
+<plugin>
+    <groupId>net.wasdev.wlp.maven.plugins</groupId>
+    <artifactId>liberty-maven-plugin</artifactId>
+    <executions>
+        ...
+        <execution>
+            <id>package-server</id>
+            <phase>package</phase>
+            <goals>
+                <goal>package-server</goal>
+            </goals>
+            <configuration>
+                <packageFile>${project.build.directory}/test.jar</packageFile>
+                <include>runnable</include>
             </configuration>
         </execution>
         ...


### PR DESCRIPTION
Issue solved: #84 

Changes to documentation:

1. package-server.md file

- Added explanation about runnable jar.
- Added option "runnable" on include parameter to package a server. 
- Added example to package a server into a runnable jar file.