### PR TITLE
Strip the appArchives version number

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -11,6 +11,7 @@ The following are the parameters supported by this goal in addition to the [comm
 | appArtifact | Maven coordinates of an application to be deployed. | Yes, if appArchive is not set. |
 | appArchive | Location of an application file to be deployed. The application type can be war, ear, rar, eba, zip, or jar. | Yes, if appArtifact is not set. |
 | timeout | Maximum time to wait (in seconds) to verify that the deployment has completed successfully. The default value is 40 seconds. | No |
+| appDeployName| The file name of the deployed application in the `dropins` directory. It is possible to use Maven properties to define it, for example `${project.artifactId}` or `${project.name}`. | No. By default, the `deployName` is the same as the original file name.|
 
 Examples:
 
@@ -29,7 +30,7 @@ Examples:
     </execution>
    ```
 
- 2. Single deploy of an application with maven coordinates.
+ 2. Single deploy of an application with Maven coordinates using the Maven property `${project.artifactId}` to change the name, this will be `webapp.war` instead of `webapp-1.0.war` .
 
   ```xml
     <execution>
@@ -45,6 +46,7 @@ Examples:
                 <version>1.0</version>
                 <type>war</type>
             </appArtifact>
+            <appDeployName>${project.artifactId}.war</appDeployName>
         </configuration>
     </execution>
   ```

--- a/liberty-maven-plugin/src/it/tests/basic-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/basic-it/pom.xml
@@ -121,6 +121,7 @@
                         </goals>
                         <configuration>
                             <appArchive>../../setup/test-war/target/test-war.war</appArchive>
+                            <appDeployName>my-test-war.war</appDeployName>
                         </configuration>
                     </execution>
                     <execution>
@@ -130,7 +131,7 @@
                             <goal>undeploy</goal>
                         </goals>
                         <configuration>
-                            <appArchive>test-war.war</appArchive>
+                            <appArchive>my-test-war.war</appArchive>
                         </configuration>
                     </execution>
                     <execution>

--- a/liberty-maven-plugin/src/it/tests/basic-it/src/test/java/net/wasdev/wlp/maven/test/app/PluginWARTest.java
+++ b/liberty-maven-plugin/src/it/tests/basic-it/src/test/java/net/wasdev/wlp/maven/test/app/PluginWARTest.java
@@ -23,7 +23,7 @@ public class PluginWARTest {
     public void testWAR() throws Exception {
         URL url = null;
         try {
-            url = new URL(baseURL + "test-war/index.jsp");
+            url = new URL(baseURL + "my-test-war/index.jsp");
             String textToFind = "Liberty";
             assertTrue(textToFind, HttpUtils.findStringInUrl(url, textToFind));
         } catch (MalformedURLException e) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DeployAppMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014-2015.
+ * (C) Copyright IBM Corporation 2014-2016.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,13 @@ public class DeployAppMojo extends BasicSupport {
      * @parameter expression="${timeout}" default-value="40"
      */
     protected int timeout = 40;
+    
+    /**
+     *  The file name of the deployed application in the `dropins` directory.
+     *
+     * @parameter expression="${appDeployName}"
+     */
+    protected String appDeployName;
 
     @Override
     protected void doExecute() throws Exception {
@@ -90,6 +97,7 @@ public class DeployAppMojo extends BasicSupport {
         deployTask.setUserDir(userDirectory);
         deployTask.setOutputDir(outputDirectory);
         deployTask.setFile(appArchive);
+        deployTask.setDeployName(appDeployName);
         // Convert from seconds to milliseconds
         deployTask.setTimeout(Long.toString(timeout*1000));
         deployTask.execute();


### PR DESCRIPTION
Issue solved: #28 

Added option to strip the version in the deployed app with the parameter appDeployName.  This parameter can be defined with Maven properties or any other string. 

Files changed:
**DeployAppMojo:** Added appDeployName parameter.
**deploy.md:** Added appDeployName parameter  and examples
**IT:** Added deploy/undeploy tests with appDeployName parameter