### PR TITLE
Minor fix on 'deploy' goal examples

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -20,7 +20,7 @@ Examples:
   ```xml
     <execution>
         <id>deploy-app</id>
-        <phase>post-integration-test</phase>
+        <phase>pre-integration-test</phase>
         <goals>
             <goal>deploy</goal>
         </goals>
@@ -35,7 +35,7 @@ Examples:
   ```xml
     <execution>
         <id>deploy-by-appArtifact</id>
-        <phase>post-integration-test</phase>
+        <phase>pre-integration-test</phase>
         <goals>
             <goal>deploy</goal>
         </goals>


### PR DESCRIPTION
It's more common to see the 'deploy' goal to be attached to the 'pre-integration-test' phase rather than the 'post-integration-test' phase.