### PR TITLE
#122: Running stop-server after mvn clean should get a warning and not an error.

### DIFF
--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
@@ -40,9 +40,10 @@ public class StopServerMojo extends StartDebugMojoSupport {
         if (skip) {
             return;
         }
-
+        
+        log.info(MessageFormat.format(messages.getString("info.server.stopping"), serverName));
+        
         if (serverDirectory.exists()) {
-            log.info(MessageFormat.format(messages.getString("info.server.stopping"), serverName));
             ServerTask serverTask = initializeJava();
             serverTask.setTimeout(Long.toString(serverStopTimeout * 1000));
             serverTask.setOperation("stop");

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014.
+ * (C) Copyright IBM Corporation 2014, 2017.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,18 +40,16 @@ public class StopServerMojo extends StartDebugMojoSupport {
         if (skip) {
             return;
         }
-        if (isInstall) {
-            installServerAssembly();
-        } else {
-            log.info(MessageFormat.format(messages.getString("info.install.type.preexisting"), ""));
-            checkServerHomeExists();
-            checkServerDirectoryExists();
-        }
 
-        log.info(MessageFormat.format(messages.getString("info.server.stopping"), serverName));
-        ServerTask serverTask = initializeJava();
-        serverTask.setTimeout(Long.toString(serverStopTimeout * 1000));
-        serverTask.setOperation("stop");
-        serverTask.execute();
+        if (serverDirectory.exists()) {
+            log.info(MessageFormat.format(messages.getString("info.server.stopping"), serverName));
+            ServerTask serverTask = initializeJava();
+            serverTask.setTimeout(Long.toString(serverStopTimeout * 1000));
+            serverTask.setOperation("stop");
+            serverTask.execute();
+        }
+        else {
+            log.info(MessageFormat.format(messages.getString("info.server.stop.noexist"), serverName));
+        }
     }
 }

--- a/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
+++ b/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
@@ -277,3 +277,8 @@ info.undeploy.patternset.useraction=No action is required.
 info.undeploy.all=CWWKM2169I: Undeploying all applications.
 info.undeploy.all.explanation=All applications in the server will be undeployed.
 info.undeploy.all.useraction=No action is required.
+
+info.server.stop.noexist=CWWKM2170I: Server {0} does not exist.
+info.server.stop.noexist.explanation=A required server does not exist.
+info.server.stop.noexist.useraction=No action is required.
+

--- a/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
+++ b/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
@@ -278,7 +278,7 @@ info.undeploy.all=CWWKM2169I: Undeploying all applications.
 info.undeploy.all.explanation=All applications in the server will be undeployed.
 info.undeploy.all.useraction=No action is required.
 
-info.server.stop.noexist=CWWKM2170I: Server {0} does not exist.
+info.server.stop.noexist=CWWKM2170I: Server {0} cannot be stopped because it does not exist.
 info.server.stop.noexist.explanation=A required server does not exist.
 info.server.stop.noexist.useraction=No action is required.
 


### PR DESCRIPTION
When server directory doesn't exist (by any reason) during 'stop-server' call, it displays 'Server does not exist' message rather than throwing an error. 