### PR TITLE
Fixed JspCompile dependency resolution

### DIFF
--- a/liberty-maven-plugin/src/it/setup/test-war/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/test-war/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -37,26 +38,13 @@
                     <version>2.3.7</version>
                 </plugin>
                 <plugin>
-                    <groupId>net.wasdev.wlp.maven.plugins</groupId>
-                    <artifactId>liberty-maven-plugin</artifactId>
-                    <version>1.3-SNAPSHOT</version>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
                     <configuration>
-                        <assemblyArtifact>
-                            <groupId>com.ibm.websphere.appserver.runtime</groupId>
-                            <artifactId>wlp-webProfile7</artifactId>
-                            <version>${wlpVersion}</version>
-                            <type>zip</type>
-                        </assemblyArtifact>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
-                </plugin>
-                <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-compiler-plugin</artifactId>
-                  <version>3.1</version>
-                  <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                  </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -70,17 +58,6 @@
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>net.wasdev.wlp.maven.plugins</groupId>
-                <artifactId>liberty-maven-plugin</artifactId>
-                 <executions>
-                      <execution> 
-                          <goals>
-                              <goal>compile-jsp</goal>
-                          </goals>
-                      </execution>
-                  </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -112,4 +89,73 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>offline-its</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                            <artifactId>liberty-maven-plugin</artifactId>
+                            <version>1.3-SNAPSHOT</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compile-jsp</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>online-its</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                            <artifactId>liberty-maven-plugin</artifactId>
+                            <version>1.3-SNAPSHOT</version>
+                            <configuration>
+                                <assemblyArtifact>
+                                    <groupId>com.ibm.websphere.appserver.runtime</groupId>
+                                    <artifactId>wlp-webProfile7</artifactId>
+                                    <version>${wlpVersion}</version>
+                                    <type>zip</type>
+                                </assemblyArtifact>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                        <artifactId>liberty-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>compile-jsp</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/jsp/CompileJspMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/jsp/CompileJspMojo.java
@@ -3,6 +3,7 @@ package net.wasdev.wlp.maven.plugins.jsp;
 import java.io.File;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Plugin;
@@ -15,11 +16,11 @@ import net.wasdev.wlp.maven.plugins.BasicSupport;
 
 /**
  * Compile the JSPs in the src/main/webapp folder.
- * 
+ *
  * @goal compile-jsp
- * 
+ *
  * @phase compile
- * 
+ *
  * @requiresDependencyResolution compile
  *
  */
@@ -27,20 +28,26 @@ public class CompileJspMojo extends BasicSupport {
 
     /**
      * The version of JSP that should be compiled against. Defaults to 2.3. Can be 2.2 or 2.3
-     * 
+     *
      * @parameter
      */
     protected String jspVersion;
-    
+
+    @Override
     protected void doExecute() throws Exception {
-        CompileJSPs compile = (CompileJSPs)ant.createTask("antlib:net/wasdev/wlp/ant:compileJSPs");
+        CompileJSPs compile = (CompileJSPs) ant.createTask("antlib:net/wasdev/wlp/ant:compileJSPs");
         if (compile == null) {
-            throw new NullPointerException("server task not found");
+            throw new NullPointerException("compileJSPs task not found");
         }
 
         compile.setInstallDir(installDirectory);
+
         compile.setSrcdir(new File("src/main/webapp"));
-        compile.setDestdir(new File("target/classes"));
+        compile.setDestdir(new File(getProject().getBuild().getOutputDirectory()));
+        compile.setTempdir(new File(getProject().getBuild().getDirectory()));
+
+        // don't delete temporary server dir
+        compile.setCleanup(false);
 
         @SuppressWarnings("unchecked")
         List<Plugin> plugins = getProject().getBuildPlugins();
@@ -67,35 +74,56 @@ public class CompileJspMojo extends BasicSupport {
             }
         }
 
-        StringBuilder builder = new StringBuilder(new File("target/classes").getAbsolutePath());
+        Set<String> classpath = new TreeSet<String>();
+
+        // first add target/classes (or whatever is configured)
+        classpath.add(getProject().getBuild().getOutputDirectory());
+
         @SuppressWarnings("unchecked")
-        Set<Artifact> dependencies = getProjectArtifacts(true);
+        Set<Artifact> dependencies = getProject().getArtifacts();
         for (Artifact dep : dependencies) {
-            File onDisk = dep.getFile();
-            if (onDisk != null) {
-                builder.append(File.pathSeparator);
-                builder.append(dep.getFile().getAbsolutePath());
+            if (!dep.isResolved()) {
+                // TODO: Is transitive=true correct here?
+                dep = resolveArtifact(dep, true);
+            }
+            if (dep.getFile() != null) {
+                if (!classpath.add(dep.getFile().getAbsolutePath())) {
+                    getLog().warn("Duplicate dependency: " + dep.getId());
+                }
             } else {
-                System.err.println("Could not find: " + dep.getGroupId() + ":" + dep.getArtifactId() + ":" + dep.getVersion());
+                getLog().warn("Could not find: " + dep.getId());
             }
         }
-        
+
+        String classpathStr = join(classpath, File.pathSeparator);
+        log.debug("Classpath: " + classpathStr);
+        compile.setClasspath(classpathStr);
+
         // TODO should we try to calculate this from a pom dependency?
         if (jspVersion != null) {
             compile.setJspVersion(jspVersion);
         }
 
-        compile.setClasspath(builder.toString());
-        
         // TODO do we need to add features?
-
         compile.execute();
+    }
+
+    private String join(Set<String> depPathes, String sep) {
+
+        StringBuilder sb = new StringBuilder();
+        for (String str : depPathes) {
+            if (sb.length() != 0) {
+                sb.append(sep);
+            }
+            sb.append(str);
+        }
+        return sb.toString();
     }
 
     @Override
     protected void init() throws MojoExecutionException, MojoFailureException {
         boolean doInstall = (installDirectory == null);
-          
+
         super.init();
 
         if (doInstall) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/jsp/CompileJspMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/jsp/CompileJspMojo.java
@@ -33,6 +33,14 @@ public class CompileJspMojo extends BasicSupport {
      */
     protected String jspVersion;
 
+    /**
+     * Timeout for JSP compile. Stop the server if the jsp compile isn't finish within the given
+     * timeout (given in seconds).
+     *
+     * @parameter default-value="30"
+     */
+    protected int timeout;
+
     @Override
     protected void doExecute() throws Exception {
         CompileJSPs compile = (CompileJSPs) ant.createTask("antlib:net/wasdev/wlp/ant:compileJSPs");
@@ -45,6 +53,7 @@ public class CompileJspMojo extends BasicSupport {
         compile.setSrcdir(new File("src/main/webapp"));
         compile.setDestdir(new File(getProject().getBuild().getOutputDirectory()));
         compile.setTempdir(new File(getProject().getBuild().getDirectory()));
+        compile.setTimeout(timeout);
 
         // don't delete temporary server dir
         compile.setCleanup(false);


### PR DESCRIPTION
- Fixed dependency resolution
- Create temp Liberty in target/compileJsp and keep it
- Get directories (target and target/classes) from maven build config
-  Allow configuring jsp compile timeout

Depends on WASdev/ci.ant#69.

DCO 1.1 Signed-off-by: Ralf Schandl <ralf.schandl@de.ibm.com>