### PR TITLE
fix webapp archetype sample EndpointIT test warning message

### DIFF
--- a/liberty-archetype-webapp/src/main/resources/archetype-resources/pom.xml
+++ b/liberty-archetype-webapp/src/main/resources/archetype-resources/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.5</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -57,11 +57,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                    <packagingExcludes>pom.xml</packagingExcludes>
-                </configuration>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>

--- a/liberty-archetype-webapp/src/main/resources/archetype-resources/src/test/java/it/EndpointIT.java
+++ b/liberty-archetype-webapp/src/main/resources/archetype-resources/src/test/java/it/EndpointIT.java
@@ -41,7 +41,7 @@ public class EndpointIT {
 
             assertEquals("HTTP GET failed", HttpStatus.SC_OK, statusCode);
 
-            String response = method.getResponseBodyAsString();
+            String response = method.getResponseBodyAsString(1000);
 
             assertTrue("Unexpected response body", response.contains("Hello! How are you today?"));
         } finally {


### PR DESCRIPTION
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running demo.wlp.it.EndpointIT
Mar 23, 2017 3:00:15 PM org.apache.commons.httpclient.HttpMethodBase getResponseBody
WARNING: Going to buffer response body of large or unknown size. Using getResponseBodyAsStream instead is recommended.