### PR TITLE
add install-server in components.xml

### DIFF
--- a/liberty-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/liberty-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -39,6 +39,7 @@
                                 org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test
                             </test>
                             <prepare-package>
+                                net.wasdev.wlp.maven.plugins:liberty-maven-plugin:install-server,
                                 net.wasdev.wlp.maven.plugins:liberty-maven-plugin:create-server,
                                 net.wasdev.wlp.maven.plugins:liberty-maven-plugin:install-feature,
                                 net.wasdev.wlp.maven.plugins:liberty-maven-plugin:install-apps


### PR DESCRIPTION
Add install-server to components.xml to generate the liberty-plugin-config file when import to WDT.

I am counting on WDT to prompt user for creating the server instance and if the project has no source, the user will not create the server instance within WDT. 