### PR TITLE
Use warSourceDirectory from war plugin configuration to generate loose application

### DIFF
--- a/liberty-archetype-webapp/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/liberty-archetype-webapp/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -7,7 +7,7 @@
         <requiredProperty key="groupId"/>
         <requiredProperty key="artifactId"/>
         <requiredProperty key="wlpRuntimeVersion">
-            <defaultValue>16.0.0.4</defaultValue>
+            <defaultValue>17.0.0.1</defaultValue>
         </requiredProperty>
         <requiredProperty key="wlpPluginVersion">
             <defaultValue>2.0-SNAPSHOT</defaultValue>

--- a/liberty-archetype-webapp/src/main/resources/archetype-resources/pom.xml
+++ b/liberty-archetype-webapp/src/main/resources/archetype-resources/pom.xml
@@ -58,6 +58,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.0.0</version>
+                <configuration>
+                    <packagingExcludes>pom.xml</packagingExcludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
@@ -41,29 +41,12 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import net.wasdev.wlp.maven.plugins.BasicSupport;
+import net.wasdev.wlp.maven.plugins.server.PluginConfigSupport;
 
 /**
  * Install artifact into Liberty server support.
  */
-public class InstallAppMojoSupport extends BasicSupport {
-
-    /**
-     * Application directory. 
-     */
-    @Parameter(property = "appsDirectory", defaultValue = "dropins")
-    protected String appsDirectory = null;
-    
-    /**
-     * Strip version. 
-     */
-    @Parameter(property = "stripVersion", defaultValue = "false")
-    protected boolean stripVersion;
-    
-    /**
-     * Loose application. 
-     */
-    @Parameter(property = "looseApplication", defaultValue = "false")
-    protected boolean looseApplication;
+public class InstallAppMojoSupport extends PluginConfigSupport {
     
     protected void installApp(Artifact artifact) throws Exception {
         if (artifact.getFile() == null) {
@@ -219,8 +202,8 @@ public class InstallAppMojoSupport extends BasicSupport {
         }
         return libraries;
     }
-    
-    private File getWarSourceDirectory() {
+ /*   
+    private File getWarSourceDirectory1() {
         // default location : ${basedir}/src/main/webapp
         File dir = new File(project.getBasedir() + "/src/main/webapp");
 
@@ -240,4 +223,5 @@ public class InstallAppMojoSupport extends BasicSupport {
         }
         return dir;
     }
+*/
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
@@ -202,26 +202,4 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
         }
         return libraries;
     }
- /*   
-    private File getWarSourceDirectory1() {
-        // default location : ${basedir}/src/main/webapp
-        File dir = new File(project.getBasedir() + "/src/main/webapp");
-
-        @SuppressWarnings("unchecked")
-        List<Plugin> plugins = getProject().getBuildPlugins();
-        for (Plugin plugin : plugins) {
-            if ("org.apache.maven.plugins:maven-war-plugin".equals(plugin.getKey())) {
-                Object config = plugin.getConfiguration();
-                if (config instanceof Xpp3Dom) {
-                    Xpp3Dom dom = (Xpp3Dom) config;
-                    Xpp3Dom val = dom.getChild("warSourceDirectory");
-                    if (val != null) {
-                        return new File(val.getValue());
-                    }
-                }
-            }
-        }
-        return dir;
-    }
-*/
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
@@ -31,12 +30,6 @@ import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
  */
 @Mojo(name = "install-apps", requiresDependencyResolution=ResolutionScope.COMPILE)
 public class InstallAppsMojo extends InstallAppMojoSupport {
-
-    /**
-     * Packages to install. One of "all", "dependencies" or "project".
-     */
-    @Parameter(property = "installAppPackages", defaultValue = "dependencies")
-    protected String installAppPackages = null;
     
     protected void doExecute() throws Exception {
         if (skip) {
@@ -96,7 +89,7 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
                         installLooseConfigApp();
                         break;
                     case "liberty-assembly":
-                        File dir = new File(project.getBasedir() + "/src/main/webapp");
+                        File dir = getWarSourceDirectory();
                         if (dir.exists()) {
                             installLooseConfigApp();
                         } else {


### PR DESCRIPTION
This pull request also updates the webapp archetype to install Liberty 17.0.0.1 runtime and cleanup the unused getSiblingModule() method.