### PR TITLE
Improve server stop behavior so that bad wlp contents does not fail build.

### DIFF
--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
@@ -42,10 +42,18 @@ public class StopServerMojo extends StartDebugMojoSupport {
         log.info(MessageFormat.format(messages.getString("info.server.stopping"), serverName));
         
         if (serverDirectory.exists()) {
-            ServerTask serverTask = initializeJava();
-            serverTask.setTimeout(Long.toString(serverStopTimeout * 1000));
-            serverTask.setOperation("stop");
-            serverTask.execute();
+            try {
+                ServerTask serverTask = initializeJava();
+                serverTask.setTimeout(Long.toString(serverStopTimeout * 1000));
+                serverTask.setOperation("stop");
+                serverTask.execute();
+            } catch (Exception e) {
+                // Most often when server stop fails, it is because the server does
+                // not fully exist in the file structure and is not running anyway.
+                // Continue with a warning rather than ending with hard failure especially
+                // as we have bound stop-server to a clean.
+                log.warn(MessageFormat.format(messages.getString("warn.server.stopped"), serverName));
+            }
         }
         else {
             log.info(MessageFormat.format(messages.getString("info.server.stop.noexist"), serverName));

--- a/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
+++ b/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
@@ -131,7 +131,7 @@ info.server.package.check.explanation=The Maven plug-in is now checking if the s
 info.server.package.check.useraction=No action is required.
 
 warn.server.stopped=CWWKM2133W: The command to stop server {0} failed. The server is probably already stopped.
-warn.server.stopped.explanation=The stop command failed. This happens most often when files are missing from the installed server.
+warn.server.stopped.explanation=The server stop command failed. This happens most often when files are missing from the installed server.
 warn.server.stopped.useraction=Plug-in processing will continue. If the server is still running, kill the server process.
 
 info.server.package=CWWKM2134I: Packaging server {0}.

--- a/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
+++ b/liberty-maven-plugin/src/main/resources/net/wasdev/wlp/maven/plugins/MvnMessages.properties
@@ -130,9 +130,9 @@ info.server.package.check=CWWKM2132I: Checking if the server has been stopped.
 info.server.package.check.explanation=The Maven plug-in is now checking if the server has been stopped
 info.server.package.check.useraction=No action is required.
 
-warn.server.stopped=CWWKM2133W: Server may not be stopped.
-warn.server.stopped.explanation=The Maven plug-in has been unable to determine if the server has been stopped. The plug-in will continue to wait until the server has been stopped.
-warn.server.stopped.useraction=Investigate why the server may not have stopped.
+warn.server.stopped=CWWKM2133W: The command to stop server {0} failed. The server is probably already stopped.
+warn.server.stopped.explanation=The stop command failed. This happens most often when files are missing from the installed server.
+warn.server.stopped.useraction=Plug-in processing will continue. If the server is still running, kill the server process.
 
 info.server.package=CWWKM2134I: Packaging server {0}.
 info.server.package.explanation=Starting to package the server.


### PR DESCRIPTION
We get errors from server stop when files are missing from the wlp folder like the server.xml, or maybe the lib folder.  When just the apps folder gets created, the rest of the server does not exist and it cannot be stopped.