### PR TITLE
Add distributionManagment in parent pom

### DIFF
--- a/liberty-maven-webapp-parent/pom.xml
+++ b/liberty-maven-webapp-parent/pom.xml
@@ -49,6 +49,19 @@
         </developer>
     </developers>
     
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+    
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Fixing deployment error:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy (default-deploy) on project liberty-maven-webapp-parent: Deployment failed: repository element was not specified in the POM inside distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter -> [Help 1]