### PR TITLE
include id and name attribute in webApplication element

### DIFF
--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/ApplicationXmlDocument.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/ApplicationXmlDocument.java
@@ -39,15 +39,17 @@ public class ApplicationXmlDocument extends XmlDocument {
         File app = new File(appFileName);
         
         if ("war".equalsIgnoreCase(appFileName.substring(appFileName.lastIndexOf(".")+1))) {
-            createElement("webApplication", "location", app.getName());
+            createElement("webApplication", app);
         } else {
-            createElement("application", "location", app.getName());
+            createElement("application", app);
         }
     }    
-    
-    public void createElement(String element, String attrKey, String attrValue) {
+ 
+    public void createElement(String element, File appFile) {
         Element child = doc.createElement(element);
-        child.setAttribute(attrKey, attrValue);
+        child.setAttribute("id", stripFileExtension(appFile.getName()));
+        child.setAttribute("location", appFile.getName());
+        child.setAttribute("name", stripFileExtension(appFile.getName()));
         doc.getDocumentElement().appendChild(child);
     }
     
@@ -70,5 +72,9 @@ public class ApplicationXmlDocument extends XmlDocument {
         } else {
             return false;
         }
+    }
+    
+    private String stripFileExtension(String filename) {
+        return filename.substring(0, filename.lastIndexOf("."));
     }
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/ApplicationXmlDocument.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/ApplicationXmlDocument.java
@@ -61,7 +61,7 @@ public class ApplicationXmlDocument extends XmlDocument {
         writeXMLDocument(applicationXml);
     }
     
-    public File getApplicationXmlFile(File serverDirectory) {
+    public static File getApplicationXmlFile(File serverDirectory) {
         File f = new File(serverDirectory, "configDropins/defaults/" + APP_XML_FILENAME); 
         return f;
     }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -39,6 +39,7 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
         }
         checkServerHomeExists();
         checkServerDirectoryExists();
+        copyConfigFiles();
         
         boolean installDependencies = false;
         boolean installProject = false;

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -39,7 +39,10 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
         }
         checkServerHomeExists();
         checkServerDirectoryExists();
+        
+        // update target server configuration
         copyConfigFiles();
+        exportParametersToXml();
         
         boolean installDependencies = false;
         boolean installProject = false;
@@ -69,8 +72,8 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
         if (applicationXml.hasChildElements()) {
             applicationXml.writeApplicationXmlDocument(serverDirectory);
         } else {
-            if (applicationXml.getApplicationXmlFile(serverDirectory).exists()) {
-                applicationXml.getApplicationXmlFile(serverDirectory).delete();
+            if (ApplicationXmlDocument.getApplicationXmlFile(serverDirectory).exists()) {
+                ApplicationXmlDocument.getApplicationXmlFile(serverDirectory).delete();
             }
         }
     }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -24,6 +24,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
+import net.wasdev.wlp.maven.plugins.ApplicationXmlDocument;
 import net.wasdev.wlp.maven.plugins.PluginConfigXmlDocument;
 import net.wasdev.wlp.maven.plugins.ServerXmlDocument;
 
@@ -115,6 +116,8 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         configDocument.createElement("assemblyInstallDirectory", assemblyInstallDirectory);
         configDocument.createElement("refresh", refresh);
         configDocument.createElement("install", install);
+        
+        configDocument.createElement("installAppsConfigDropins", ApplicationXmlDocument.getApplicationXmlFile(serverDirectory));
         
         // write XML document to file
         File f = new File(project.getBuild().getDirectory() + File.separator + PLUGIN_CONFIG_XML);


### PR DESCRIPTION
To avoid the error `CWWKZ0013E: It is not possible to start two applications called ServletSample` during server start, the generated webApplication element in install_apps_configuration_1491924271.xml must match to the one generated by WDT in target server.xml, which include id and name attribute.

`<webApplication id="ServletSample" location="ServletSample.war" name="ServletSample"/>`