### PR TITLE
Move install-apps to package phase

### DIFF
--- a/liberty-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/liberty-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -42,9 +42,9 @@
                                 net.wasdev.wlp.maven.plugins:liberty-maven-plugin:install-server,
                                 net.wasdev.wlp.maven.plugins:liberty-maven-plugin:create-server,
                                 net.wasdev.wlp.maven.plugins:liberty-maven-plugin:install-feature,
-                                net.wasdev.wlp.maven.plugins:liberty-maven-plugin:install-apps
                             </prepare-package>
                             <package>
+                                net.wasdev.wlp.maven.plugins:liberty-maven-plugin:install-apps,
                                 net.wasdev.wlp.maven.plugins:liberty-maven-plugin:package-server
                             </package>
                             <pre-integration-test>


### PR DESCRIPTION
Moving install-apps to the package phase to be consistent with the parent pom and to give the user a better chance to build a war during the prepare-package phase.