### PR TITLE
Fixed some problems found in merge review

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Example:
 
 ### liberty-plugin-archetype
 
-`liberty-plugin-archetype` is used to generate a basic multi-module project that builds a simple web application then deploys and tests is on a Liberty server. It also creates a Liberty server package that includes the application.
+`liberty-plugin-archetype` is used to generate a basic multi-module project that builds a simple web application then deploys and tests it on a Liberty server. It also creates a Liberty server package that includes the application.
 
 #### Usage
 

--- a/docs/common-parameters.md
+++ b/docs/common-parameters.md
@@ -4,14 +4,14 @@ Parameters shared by all goals.
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| installDirectory | Local installation directory of the Liberty profile server. | Yes, only when `assemblyArchive`, `assemblyArtifact`, and `install` parameters are not set. |
-| assemblyArchive | Location of the Liberty profile server compressed archive. The archive will be unpacked into a directory as specified by the `assemblyInstallDirectory` parameter. | Yes, only when `installDirectory`, `assemblyArtifact`, and `install` parameters are not set. |
-| assemblyArtifact | Maven artifact name of the Liberty profile server assembly. The assembly will be installed into a directory as specified by the `assemblyInstallDirectory` parameter. | Yes, only when `installDirectory`, `assemblyArchive`, and `install` parameters are not set. |
+| installDirectory | Local installation directory of the Liberty server. | Yes, only when `assemblyArchive`, `assemblyArtifact`, and `install` parameters are not set. |
+| assemblyArchive | Location of the Liberty server compressed archive. The archive will be unpacked into a directory as specified by the `assemblyInstallDirectory` parameter. | Yes, only when `installDirectory`, `assemblyArtifact`, and `install` parameters are not set. |
+| assemblyArtifact | Maven artifact name of the Liberty server assembly. The assembly will be installed into a directory as specified by the `assemblyInstallDirectory` parameter. | Yes, only when `installDirectory`, `assemblyArchive`, and `install` parameters are not set. |
 | install | Install Liberty runtime from the [Liberty repository](docs/installation-configuration.md#using-a-repository). | Yes, only when `installDirectory`, `assemblyArchive`, and `assemblyArtifact` parameters are not set. |
 | licenseArtifact | Maven artifact name of the Liberty license jar. It will be used to upgrade the installation at the location specified by the `assemblyInstallDirectory` parameter. | No |
-| serverName | Name of the Liberty profile server instance. The default value is `defaultServer`. | No |
+| serverName | Name of the Liberty server instance. The default value is `defaultServer`. | No |
 | userDirectory | Alternative user directory location that contains server definitions and shared resources (`WLP_USER_DIR`). | No |
 | outputDirectory | Alternative location for server generated output such as logs, the _workarea_ directory, and other generated files (`WLP_OUTPUT_DIR`). | No |
-| assemblyInstallDirectory | Local installation directory location of the Liberty profile server when the server is installed using the assembly archive, assembly artifact or repository option. The default value is `${project.build.directory}/liberty`.  | No |
-| refresh | If true, re-install Liberty profile server into the local directory. This is only used when when the server is installed using the assembly archive or artifact option. The default value is false. | No |
+| assemblyInstallDirectory | Local installation directory location of the Liberty server when the server is installed using the assembly archive, assembly artifact or repository option. The default value is `${project.build.directory}/liberty`.  | No |
+| refresh | If true, re-install Liberty server into the local directory. This is only used when when the server is installed using the assembly archive or artifact option. The default value is false. | No |
 | skip | If true, the specified goal is bypassed entirely. The default value is false. | No |

--- a/docs/create-server.md
+++ b/docs/create-server.md
@@ -1,6 +1,6 @@
 #### create-server
 ---
-Create a Liberty Profile server.
+Create a Liberty server.
 
 ###### Additional Parameters
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,6 @@
 #### deploy
 ---
-Deploy an application to a Liberty Profile server. The server instance must exist and must be running.
+Deploy an application to a Liberty server. The server instance must exist and must be running.
 
 ###### Additional Parameters
 

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -37,7 +37,7 @@ The Maven Central repository includes the following Liberty runtime artifacts:
 | [wlp-webProfile7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile7/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with Java EE 7 Web Profile features. |
 | [wlp-kernel](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-kernel/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime kernel. |
 | [wlp-osgi](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-osgi/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime with features that support OSGi applications. |
-| [wlp-microProfile1](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-microProfile1/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty with features for a MicroProfile runtime. |
+| [wlp-microProfile1](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-microProfile1/) | 17.0.0.1, 16.0.0.4, 16.0.0.3 | Liberty with features for a MicroProfile runtime. |
 
 
 Note: The group ID for these artifacts is: `com.ibm.websphere.appserver.runtime`.

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,7 +1,7 @@
 ### Liberty installation configuration
 #### Using an existing installation
 
-Use the `installDirectory` parameter to specify the directory of an existing Liberty profile server installation. For example:
+Use the `installDirectory` parameter to specify the directory of an existing Liberty server installation. For example:
 ```xml
 <plugin>
     <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -14,7 +14,7 @@ Use the `installDirectory` parameter to specify the directory of an existing Lib
 
 #### Using a packaged server
 
-Use the `assemblyArchive` parameter to specify a packaged server archive (created using `server package` command) that contains Liberty profile server files. For example:
+Use the `assemblyArchive` parameter to specify a packaged server archive (created using `server package` command) that contains Liberty server files. For example:
 ```xml
 <plugin>
     <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -27,16 +27,16 @@ Use the `assemblyArchive` parameter to specify a packaged server archive (create
 
 #### Using Maven artifact
 
-Use the `assemblyArtifact` parameter to specify the name of the Maven artifact that contains a custom Liberty profile server or use one of the provided on the [Maven Central repository](http://search.maven.org/). 
+Use the `assemblyArtifact` parameter to specify the name of the Maven artifact that contains a custom Liberty server or use one of the provided on the [Maven Central repository](http://search.maven.org/). 
 
 The Maven Central repository includes the following Liberty runtime artifacts:
 
 |Artifact ID | Versions | Description |
 | --- | ----------------- | ----------- |
-| [wlp-javaee7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/) | 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with all Java EE 7 Full Platform features. |
-| [wlp-webProfile7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile7/) | 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with Java EE 7 Web Profile features. |
-| [wlp-kernel](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-kernel/) | 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime kernel. |
-| [wlp-osgi](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-osgi/) | 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime with features that support OSGi applications. |
+| [wlp-javaee7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with all Java EE 7 Full Platform features. |
+| [wlp-webProfile7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile7/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with Java EE 7 Web Profile features. |
+| [wlp-kernel](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-kernel/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime kernel. |
+| [wlp-osgi](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-osgi/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime with features that support OSGi applications. |
 
 
 Note: The group ID for these artifacts is: `com.ibm.websphere.appserver.runtime`.
@@ -59,7 +59,7 @@ Example for using the `assemblyArtifact` parameter:
 
 #### Using a repository
 
-Use the `install` parameter to download and install Liberty profile server from the [Liberty repository](https://developer.ibm.com/wasdev/downloads/) or other location.
+Use the `install` parameter to download and install Liberty server from the [Liberty repository](https://developer.ibm.com/wasdev/downloads/) or other location.
 
 In certain cases, the Liberty license code may need to be provided in order to install the runtime. If the license code is required and if you are installing Liberty from the Liberty repository, you can obtain the license code by reading the [current license](https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/16.0.0.2/lafiles/runtime/en.html) and looking for the `D/N: <license code>` line. Otherwise, download the Liberty runtime archive and execute `java -jar wlp*runtime.jar --viewLicenseInfo` command and look for the `D/N: <license code>` line.
 
@@ -85,7 +85,7 @@ In certain cases, the Liberty license code may need to be provided in order to i
     </plugin>
  ```
 
-* Install from a given location. The `runtimeUrl` sub-parameter specifies a location of the Liberty profile's runtime `.jar` or `.zip` file to install. The `licenseCode` is only needed when installing from `.jar` file.
+* Install from a given location. The `runtimeUrl` sub-parameter specifies a location of the Liberty's runtime `.jar` or `.zip` file to install. The `licenseCode` is only needed when installing from `.jar` file.
  ```xml
     <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -103,10 +103,10 @@ The `install` parameter has the following sub-parameters:
 
 | Name | Description | Required |
 | --------  | ----------- | -------  |
-| licenseCode | Liberty profile license code. See [above](#using-a-repository). | Yes, if `type` is `webProfile6` or `runtimeUrl` specifies a `.jar` file. |
-| version | Exact or wildcard version of the Liberty profile server to install. Available versions are listed in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file. Only used if `runtimeUrl` is not set. The default value is `8.5.+`. | No |
+| licenseCode | Liberty license code. See [above](#using-a-repository). | Yes, if `type` is `webProfile6` or `runtimeUrl` specifies a `.jar` file. |
+| version | Exact or wildcard version of the Liberty server to install. Available versions are listed in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file. Only used if `runtimeUrl` is not set. The default value is `8.5.+`. | No |
 | type | Liberty runtime type to download from the Liberty repository. Currently, the following types are supported: `kernel`, `webProfile6`, `webProfile7`, and `javaee7`. Only used if `runtimeUrl` is not set. Defaults to `webProfile6` if `licenseCode` is set and `webProfile7` otherwise. | No |
-| runtimeUrl | URL to the Liberty profile's runtime `.jar` or a `.zip` file. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
+| runtimeUrl | URL to the Liberty's runtime `.jar` or a `.zip` file. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
 | cacheDirectory | The directory used for caching downloaded files such as the license or `.jar` files. The default value is `${settings.localRepository}/wlp-cache`. | No |
 | username | Username needed for basic authentication. | No |
 | password | Password needed for basic authentication. | No |

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -85,7 +85,7 @@ In certain cases, the Liberty license code may need to be provided in order to i
     </plugin>
  ```
 
-* Install from a given location. The `runtimeUrl` sub-parameter specifies a location of the Liberty's runtime `.jar` or `.zip` file to install. The `licenseCode` is only needed when installing from `.jar` file.
+* Install from a given location. The `runtimeUrl` sub-parameter specifies a location of the Liberty runtime `.jar` or `.zip` file to install. The `licenseCode` is only needed when installing from `.jar` file.
  ```xml
     <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
@@ -106,7 +106,7 @@ The `install` parameter has the following sub-parameters:
 | licenseCode | Liberty license code. See [above](#using-a-repository). | Yes, if `type` is `webProfile6` or `runtimeUrl` specifies a `.jar` file. |
 | version | Exact or wildcard version of the Liberty server to install. Available versions are listed in the [index.yml](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml) file. Only used if `runtimeUrl` is not set. The default value is `8.5.+`. | No |
 | type | Liberty runtime type to download from the Liberty repository. Currently, the following types are supported: `kernel`, `webProfile6`, `webProfile7`, and `javaee7`. Only used if `runtimeUrl` is not set. Defaults to `webProfile6` if `licenseCode` is set and `webProfile7` otherwise. | No |
-| runtimeUrl | URL to the Liberty's runtime `.jar` or a `.zip` file. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
+| runtimeUrl | URL to the Liberty runtime `.jar` or a `.zip` file. If not set, the Liberty repository will be used to find the Liberty runtime archive. | No |
 | cacheDirectory | The directory used for caching downloaded files such as the license or `.jar` files. The default value is `${settings.localRepository}/wlp-cache`. | No |
 | username | Username needed for basic authentication. | No |
 | password | Password needed for basic authentication. | No |

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -33,10 +33,11 @@ The Maven Central repository includes the following Liberty runtime artifacts:
 
 |Artifact ID | Versions | Description |
 | --- | ----------------- | ----------- |
-| [wlp-javaee7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with all Java EE 7 Full Platform features. |
-| [wlp-webProfile7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile7/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with Java EE 7 Web Profile features. |
-| [wlp-kernel](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-kernel/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime kernel. |
-| [wlp-osgi](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-osgi/) | 17.0.0.1, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime with features that support OSGi applications. |
+| [wlp-javaee7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-javaee7/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with all Java EE 7 Full Platform features. |
+| [wlp-webProfile7](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile7/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with Java EE 7 Web Profile features. |
+| [wlp-kernel](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-kernel/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime kernel. |
+| [wlp-osgi](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-osgi/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty runtime with features that support OSGi applications. |
+| [wlp-microProfile1](https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-microProfile1/) | 17.0.0.1, 16.0.0.4, 16.0.0.3, 16.0.0.2, 8.5.5.9, 8.5.5.8 | Liberty with features for a MicroProfile runtime. |
 
 
 Note: The group ID for these artifacts is: `com.ibm.websphere.appserver.runtime`.

--- a/docs/package-server.md
+++ b/docs/package-server.md
@@ -1,6 +1,6 @@
 #### package-server
 ---
-Package a Liberty Profile server.
+Package a Liberty server.
 
 Starting with WebSphere Liberty 8.5.5.9, it is possible to package a server into an executable jar file by setting the `include` parameter to `runnable`. The created jar file can be executed using the `java -jar` command.
 

--- a/docs/run-server.md
+++ b/docs/run-server.md
@@ -1,6 +1,6 @@
 #### run-server
 ---
-Start a Liberty Profile server in foreground. The server instance will be automatically created if it does not exist.
+Start a Liberty server in foreground. The server instance will be automatically created if it does not exist.
 **Note:** This goal is designed to be executed directly from the Maven command line.
 
 ###### Additional Parameters

--- a/docs/start-server.md
+++ b/docs/start-server.md
@@ -1,6 +1,6 @@
 #### start-server
 ---
-Start a Liberty Profile server in background. The server instance will be automatically created if it does not exist.
+Start a Liberty server in background. The server instance will be automatically created if it does not exist.
 
 ###### Additional Parameters
 

--- a/docs/stop-server.md
+++ b/docs/stop-server.md
@@ -1,6 +1,6 @@
 #### stop-server
 ---
-Stop a Liberty Profile server. The server instance must exist and must be running.
+Stop a Liberty server. The server instance must exist and must be running.
 
 ###### Additional Parameters
 

--- a/docs/test-start-server.md
+++ b/docs/test-start-server.md
@@ -16,7 +16,7 @@ Example:
     ...
     <groupId>myGroup</groupId>
     <artifactId>myServer</artifactId>
-    <!-- Create Liberty profile server assembly -->
+    <!-- Create Liberty server assembly -->
     <packaging>liberty-assembly</packaging>
     ...
     <build>

--- a/docs/test-stop-server.md
+++ b/docs/test-stop-server.md
@@ -16,7 +16,7 @@ Example:
     ...
     <groupId>myGroup</groupId>
     <artifactId>myServer</artifactId>
-    <!-- Create Liberty profile server assembly -->
+    <!-- Create Liberty server assembly -->
     <packaging>liberty-assembly</packaging>
     ...
     <build>

--- a/docs/undeploy.md
+++ b/docs/undeploy.md
@@ -1,6 +1,6 @@
 #### undeploy
 ---
-Undeploy an application to a Liberty Profile server. The server instance must exist and must be running. If appArtifact or appArchive are not defined, the goal will undeploy all applications from the server.
+Undeploy an application to a Liberty server. The server instance must exist and must be running. If appArtifact or appArchive are not defined, the goal will undeploy all applications from the server.
 
 ###### Additional Parameters
 

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DeployAppMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014-2017.
+ * (C) Copyright IBM Corporation 2014, 2017.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/UndeployAppMojo.java
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corporation 2014-2015, 2017.
+ * (C) Copyright IBM Corporation 2014, 2017.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
README.md
 ### liberty-plugin-archetype
- [x] tests is on a Liberty server. >>> tests it on a Liberty server.

docs/installation-configuration.md
- [x] The table does not refer to runtimes later than 16.0.0.2. This should be updated. For example: 
| wlp-javaee7 | 16.0.0.2, 8.5.5.9, 8.5.5.8, 8.5.5.7, 8.5.5.6 | Liberty runtime with all Java EE 7 Full Platform features. |

docs/run-server.md
- [x] "Start a Liberty Profile server" - make one more sweep to get rid of "Profile"
- [x] Also see it in docs/start-server.md and others.

/src/main/java/net/wasdev/wlp/maven/plugins/applications/DeployAppMojo.java
fix copyright
(C) Copyright IBM Corporation 2014-2017.
- [x] (C) Copyright IBM Corporation 2014, 2017.
src/main/java/net/wasdev/wlp/maven/plugins/applications/UndeployAppMojo.java
fix copyright
(C) Copyright IBM Corporation 2014-2015, 2017.
- [x] (C) Copyright IBM Corporation 2014, 2017.