### PR TITLE
Got rid of warning message. 

### DIFF
--- a/liberty-maven-plugin/src/it/tests/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
-	
+
     <modules>
         <module>test-assembly</module>
         <module>assembly-it</module>
@@ -25,18 +25,23 @@
         <module>test-assembly-with-code-it</module>
         <module>config-packagefile-runnable-it</module>
         <module>config-packagefile-all-it</module>
+        <module>appsdirectory-apps-configured-bootstraps-it</module>  
         <module>appsdirectory-apps-configured-it</module>     
-        <module>appsdirectory-apps-notconfigured-it</module>    
+        <module>appsdirectory-apps-configured-variables-it</module>         
         <module>appsdirectory-apps-dependency-notconfigured-it</module>
         <module>appsdirectory-apps-notconfigured-dependency-configured-it</module>
+        <module>appsdirectory-apps-notconfigured-it</module>    
+        <module>appsdirectory-configdropins-it</module>
         <module>appsdirectory-dropins-notconfigured-it</module>     
+        <module>appsdirectory-include-configured-it</module>
         <module>appsdirectory-notset-configured-it</module>     
         <module>appsdirectory-notset-notconfigured-it</module>
         <module>appsdirectory-set-appz-configured-it</module>
         <module>appsdirectory-set-appz-notconfigured-it</module>
-        <module>appsdirectory-include-configured-it</module>
-        <module>appsdirectory-configdropins-it</module>
         <module>skip-start-server-it</module>
+        <module>test-server-param-default</module>
+        <module>test-server-param-pom-override</module>
+        <module>test-server-param-configdir-override</module>
     </modules>
 	<profiles>
         <profile>

--- a/liberty-maven-plugin/src/it/tests/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/pom.xml
@@ -43,7 +43,7 @@
         <module>test-server-param-pom-override</module>
         <module>test-server-param-configdir-override</module>
     </modules>
-	<profiles>
+    <profiles>
         <profile>
             <id>online-its</id>
         </profile>

--- a/liberty-maven-plugin/src/it/tests/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
-
+	
     <modules>
         <module>test-assembly</module>
         <module>assembly-it</module>
@@ -25,22 +25,25 @@
         <module>test-assembly-with-code-it</module>
         <module>config-packagefile-runnable-it</module>
         <module>config-packagefile-all-it</module>
-        <module>appsdirectory-apps-configured-bootstraps-it</module>  
         <module>appsdirectory-apps-configured-it</module>     
-        <module>appsdirectory-apps-configured-variables-it</module>         
+        <module>appsdirectory-apps-notconfigured-it</module>    
         <module>appsdirectory-apps-dependency-notconfigured-it</module>
         <module>appsdirectory-apps-notconfigured-dependency-configured-it</module>
-        <module>appsdirectory-apps-notconfigured-it</module>    
-        <module>appsdirectory-configdropins-it</module>
         <module>appsdirectory-dropins-notconfigured-it</module>     
-        <module>appsdirectory-include-configured-it</module>
         <module>appsdirectory-notset-configured-it</module>     
         <module>appsdirectory-notset-notconfigured-it</module>
         <module>appsdirectory-set-appz-configured-it</module>
         <module>appsdirectory-set-appz-notconfigured-it</module>
+        <module>appsdirectory-include-configured-it</module>
+        <module>appsdirectory-configdropins-it</module>
         <module>skip-start-server-it</module>
-        <module>test-server-param-default</module>
-        <module>test-server-param-pom-override</module>
-        <module>test-server-param-configdir-override</module>
     </modules>
+	<profiles>
+        <profile>
+            <id>online-its</id>
+        </profile>
+        <profile>
+            <id>offline-its</id>
+        </profile>
+    </profiles>
 </project>

--- a/liberty-maven-plugin/src/it/tests/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/pom.xml
@@ -43,6 +43,7 @@
         <module>test-server-param-pom-override</module>
         <module>test-server-param-configdir-override</module>
     </modules>
+<!--These profiles are included to suppress warnings that they are missing whenever tests are ran -->
     <profiles>
         <profile>
             <id>online-its</id>

--- a/liberty-plugin-archetype/src/it/projects/basic/pom.xml
+++ b/liberty-plugin-archetype/src/it/projects/basic/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.wasdev.wlp.maven.it</groupId>
+    <artifactId>basic</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+	<profiles>
+        <profile>
+            <id>online-its</id>
+        </profile>
+        <profile>
+            <id>offline-its</id>
+        </profile>
+    </profiles>
+</project>

--- a/liberty-plugin-archetype/src/it/projects/basic/pom.xml
+++ b/liberty-plugin-archetype/src/it/projects/basic/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
-	<profiles>
+    <profiles>
         <profile>
             <id>online-its</id>
         </profile>

--- a/liberty-plugin-archetype/src/it/projects/basic/pom.xml
+++ b/liberty-plugin-archetype/src/it/projects/basic/pom.xml
@@ -12,6 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
+<!--These profiles are included to suppress warnings that they are missing whenever tests are ran -->
     <profiles>
         <profile>
             <id>online-its</id>


### PR DESCRIPTION
Messages
[WARNING] The requested profile "online-its" could not be activated because it does not exist and
[WARNING] The requested profile "offline-its" could not be activated because it does not exist

no longer show up. 
