### PR TITLE
set ci.ant version for release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>net.wasdev.wlp.ant</groupId>
                 <artifactId>wlp-anttasks</artifactId>
-                <version>1.4-SNAPSHOT</version>
+                <version>1.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The ci.maven release will use the current ant 1.3 release.