### PR TITLE
update main project parent pom

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To enable `liberty-maven-plugin` in your project add the following to your `pom.
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>1.2</version>
+                <version>2.0</version>
                 <!-- Specify configuration, executions for liberty-maven-plugin -->
                 ...
             </plugin>
@@ -166,7 +166,7 @@ Example:
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>1.2</version>
+                <version>2.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <installDirectory>/opt/ibm/wlp</installDirectory>
@@ -195,8 +195,8 @@ Example:
     mvn archetype:generate \
         -DarchetypeGroupId=net.wasdev.wlp.maven \
         -DarchetypeArtifactId=liberty-plugin-archetype \
-        -DarchetypeVersion=1.2 \
-        -DwlpPluginVersion=1.2 \
+        -DarchetypeVersion=2.0 \
+        -DwlpPluginVersion=2.0 \
         -DgroupId=test \
         -DartifactId=test \
         -Dversion=1.0-SNAPSHOT
@@ -210,8 +210,8 @@ Example:
     mvn archetype:generate \
         -DarchetypeGroupId=net.wasdev.wlp.maven \
         -DarchetypeArtifactId=liberty-archetype-webapp \
-        -DarchetypeVersion=2.0-SNAPSHOT \
-        -DwlpPluginVersion=2.0-SNAPSHOT \
+        -DarchetypeVersion=2.0 \
+        -DwlpPluginVersion=2.0 \
         -DgroupId=test \
         -DartifactId=test \
         -Dversion=1.0-SNAPSHOT

--- a/liberty-archetype-webapp/pom.xml
+++ b/liberty-archetype-webapp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.0</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>liberty-archetype-webapp</artifactId>

--- a/liberty-archetype-webapp/pom.xml
+++ b/liberty-archetype-webapp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <artifactId>liberty-archetype-webapp</artifactId>

--- a/liberty-maven-app-parent/pom.xml
+++ b/liberty-maven-app-parent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.0</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     
     <groupId>net.wasdev.wlp.maven.parent</groupId>

--- a/liberty-maven-app-parent/pom.xml
+++ b/liberty-maven-app-parent/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
     
     <groupId>net.wasdev.wlp.maven.parent</groupId>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.0</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>net.wasdev.wlp.maven.plugins</groupId>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -91,6 +91,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.8</version>
                         <configuration>
                             <debug>false</debug>
                             <goals>
@@ -120,4 +121,8 @@
             </build>
         </profile>
     </profiles>
+
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
 </project>

--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <groupId>net.wasdev.wlp.maven.plugins</groupId>

--- a/liberty-maven-plugin/src/it/setup/test-war/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/test-war/pom.xml
@@ -93,7 +93,7 @@
                         <plugin>
                             <groupId>net.wasdev.wlp.maven.plugins</groupId>
                             <artifactId>liberty-maven-plugin</artifactId>
-                            <version>2.0-SNAPSHOT</version>
+                            <version>@pom.version@</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>
@@ -120,7 +120,7 @@
                         <plugin>
                             <groupId>net.wasdev.wlp.maven.plugins</groupId>
                             <artifactId>liberty-maven-plugin</artifactId>
-                            <version>2.0-SNAPSHOT</version>
+                            <version>@pom.version@</version>
                             <configuration>
                                 <assemblyArtifact>
                                     <groupId>com.ibm.websphere.appserver.runtime</groupId>

--- a/liberty-plugin-archetype/pom.xml
+++ b/liberty-plugin-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.0</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>liberty-plugin-archetype</artifactId>

--- a/liberty-plugin-archetype/pom.xml
+++ b/liberty-plugin-archetype/pom.xml
@@ -160,6 +160,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.8</version>
                         <inherited>true</inherited>
                         <executions>
                             <execution>

--- a/liberty-plugin-archetype/pom.xml
+++ b/liberty-plugin-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven</groupId>
         <artifactId>liberty-maven</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.0</version>
     </parent>
 
     <artifactId>liberty-plugin-archetype</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <parent>
         <groupId>net.wasdev.maven.parent</groupId>
-        <artifactId>java7-parent</artifactId>
+        <artifactId>parent</artifactId>
         <version>1.4</version>
         <relativePath />
     </parent>
@@ -33,8 +33,8 @@
         <connection>scm:git:git@github.com:WASdev/ci.maven.git</connection>
         <developerConnection>scm:git:git@github.com:WASdev/ci.maven.git</developerConnection>
         <url>git@github.com:WASdev/ci.maven.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <developers>
         <developer>
@@ -43,6 +43,13 @@
             <email>jgawor@gmail.com</email>
         </developer>
     </developers>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -60,8 +67,4 @@
         <module>liberty-plugin-archetype</module>
         <module>liberty-archetype-webapp</module>
     </modules>
-
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.wasdev.wlp.maven</groupId>
     <artifactId>liberty-maven</artifactId>
-    <version>2.0</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WebSphere Application Server Liberty Profile Maven Tools</name>
     <description>
@@ -33,7 +33,7 @@
         <connection>scm:git:git@github.com:WASdev/ci.maven.git</connection>
         <developerConnection>scm:git:git@github.com:WASdev/ci.maven.git</developerConnection>
         <url>git@github.com:WASdev/ci.maven.git</url>
-      <tag>liberty-maven-2.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.wasdev.wlp.maven</groupId>
     <artifactId>liberty-maven</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.0</version>
     <packaging>pom</packaging>
     <name>WebSphere Application Server Liberty Profile Maven Tools</name>
     <description>
@@ -33,7 +33,7 @@
         <connection>scm:git:git@github.com:WASdev/ci.maven.git</connection>
         <developerConnection>scm:git:git@github.com:WASdev/ci.maven.git</developerConnection>
         <url>git@github.com:WASdev/ci.maven.git</url>
-      <tag>HEAD</tag>
+      <tag>liberty-maven-2.0</tag>
   </scm>
 
     <developers>


### PR DESCRIPTION
Update main project parent pom and fix build warnings. 

If liberty-maven-app-parent inherents from net.wasdev.maven.parent:java7-parent, it has plugin dependencies on maven-enforcer-plugin and maven-remote-resources-plugin which will be ignored by eclipse m2e plugin and generates 2 warnings in Eclipse/WDT.  
~~~
maven-enforcer-plugin (goal "enforce") is ignored by m2e.	
maven-remote-resources-plugin (goal "process") is ignored by m2e. 
~~~

The solution is to set the parent of the main project pom to the parent of net.wasdev.maven.parent:java7-parent and set the compile level to 1.7 in the main project pom.