### PR TITLE
removed unused serverStopTimeout parameter from stop-server

### DIFF
--- a/docs/stop-server.md
+++ b/docs/stop-server.md
@@ -4,11 +4,11 @@ Stop a Liberty server. The server instance must exist and must be running.
 
 ###### Additional Parameters
 
-The following are the parameters supported by this goal in addition to the [common server parameters](common-server-parameters.md#common-server-parameters) and the [common parameters](common-parameters.md#common-parameters).
+This goal supports [common server parameters](common-server-parameters.md#common-server-parameters) and [common parameters](common-parameters.md#common-parameters).
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| serverStopTimeout | Maximum time to wait (in seconds) to verify that the server has stopped. The default value is 30 seconds. | No |
+| serverStopTimeout | Deprecated. This parameter is ignored. Maximum time to wait (in seconds) to verify that the server has stopped. The default value is 30 seconds. | Ignored |
 
 Example:
 ```xml
@@ -23,9 +23,6 @@ Example:
             <goals>
                 <goal>stop-server</goal>
             </goals>
-            <configuration>
-                <serverStopTimeout>60</serverStopTimeout>
-            </configuration>
         </execution>
         ...
     </executions>

--- a/docs/stop-server.md
+++ b/docs/stop-server.md
@@ -8,7 +8,7 @@ This goal supports [common server parameters](common-server-parameters.md#common
 
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
-| serverStopTimeout | Deprecated. This parameter is ignored. Maximum time to wait (in seconds) to verify that the server has stopped. The default value is 30 seconds. | Ignored |
+| serverStopTimeout | Deprecated. This parameter is ignored. | No |
 
 Example:
 ```xml

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
@@ -28,7 +28,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 public class StopServerMojo extends StartDebugMojoSupport {
 
     /**
-     * Timeout to verify stop successfully
+     * Timeout to verify stop successfully, this parameter is ignored
      */
     @Parameter(property = "serverStopTimeout", defaultValue = "30")
     protected long serverStopTimeout = 30;
@@ -44,7 +44,6 @@ public class StopServerMojo extends StartDebugMojoSupport {
         if (serverDirectory.exists()) {
             try {
                 ServerTask serverTask = initializeJava();
-                serverTask.setTimeout(Long.toString(serverStopTimeout * 1000));
                 serverTask.setOperation("stop");
                 serverTask.execute();
             } catch (Exception e) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
@@ -27,12 +27,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 @Mojo(name = "stop-server") 
 public class StopServerMojo extends StartDebugMojoSupport {
 
-    /**
-     * Timeout to verify stop successfully, this parameter is ignored
-     */
-    @Parameter(property = "serverStopTimeout", defaultValue = "30")
-    protected long serverStopTimeout = 30;
-
     @Override
     protected void doExecute() throws Exception {
         if (skip) {


### PR DESCRIPTION
We found that this parameter was not used outside of the Maven plugin while looking into a Gradle plugin issue. https://github.ibm.com/was-liberty/ecosystem/issues/118