### PR TITLE
set installAppPackages default value for ear project

### DIFF
--- a/docs/install-apps.md
+++ b/docs/install-apps.md
@@ -10,7 +10,7 @@ The following are the parameters supported by this goal in addition to the [comm
 | --------  | ----------- | -------  |
 | appsDirectory | The server's `apps` or `dropins` directory where the application files should be copied. The default value is set to `apps` if the application is defined in the server configuration, otherwise it is set to `dropins`.  | No |
 | stripVersion | Strip artifact version when copying the application to Liberty runtime's application directory. The default value is `false`. | No |
-| installAppPackages | The Maven packages to copy to Liberty runtime's application directory. One of `dependencies`, `project` or `all`. The default is `dependencies`.<br>For ear type project, this parameter is ignored and only the project package will be copied. | No |
+| installAppPackages | The Maven packages to copy to Liberty runtime's application directory. One of `dependencies`, `project` or `all`. The default is `dependencies`.<br>For an ear type project, this parameter is ignored and only the project package is installed. | No |
 | looseApplication | Generate a loose application configuration file representing the Maven project package and copy it to the Liberty server's `apps` or `dropins` directory. The default value is `false`. This parameter is ignored if `installAppPackages` is set to `dependencies` or if the project packaging type is neither `war` nor `liberty-assembly`. When using the packaging type `liberty-assembly`, using a combination of `installAppPackages` set to `all` or `project` and `looseApplication` set to `true` results in the installation of application code provided in the project without the need of adding additional goals to your POM file. | No |
 
 Example:

--- a/docs/install-apps.md
+++ b/docs/install-apps.md
@@ -10,7 +10,7 @@ The following are the parameters supported by this goal in addition to the [comm
 | --------  | ----------- | -------  |
 | appsDirectory | The server's `apps` or `dropins` directory where the application files should be copied. The default value is set to `apps` if the application is defined in the server configuration, otherwise it is set to `dropins`.  | No |
 | stripVersion | Strip artifact version when copying the application to Liberty runtime's application directory. The default value is `false`. | No |
-| installAppPackages | The Maven packages to copy to Liberty runtime's application directory. One of `dependencies`, `project` or `all`. The default is `dependencies`. | No |
+| installAppPackages | The Maven packages to copy to Liberty runtime's application directory. One of `dependencies`, `project` or `all`. The default is `dependencies`.<br>For ear type project, this parameter is ignored and only the project package will be copied. | No |
 | looseApplication | Generate a loose application configuration file representing the Maven project package and copy it to the Liberty server's `apps` or `dropins` directory. The default value is `false`. This parameter is ignored if `installAppPackages` is set to `dependencies` or if the project packaging type is neither `war` nor `liberty-assembly`. When using the packaging type `liberty-assembly`, using a combination of `installAppPackages` set to `all` or `project` and `looseApplication` set to `true` results in the installation of application code provided in the project without the need of adding additional goals to your POM file. | No |
 
 Example:

--- a/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/pom.xml
@@ -71,7 +71,6 @@
                     <serverName>test</serverName>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <appsDirectory>apps</appsDirectory>
-                    <installAppPackages>project</installAppPackages>
                     <looseApplication>false</looseApplication>
                     <include>usr</include>
                 </configuration>

--- a/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/PluginConfigXmlIT.java
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/PluginConfigXmlIT.java
@@ -1,0 +1,53 @@
+package net.wasdev.wlp.maven.test.it;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import static junit.framework.Assert.*;
+
+public class PluginConfigXmlIT {
+    
+    public final String CONFIG_XML = "liberty-plugin-config.xml";
+    
+    @Test
+    public void testConfigPropFileExist() throws Exception {
+        File f = new File(CONFIG_XML);
+        assertTrue(f.getCanonicalFile() + " doesn't exist", f.exists());
+    }
+    
+    @Test
+    public void testXmlElements() throws Exception {
+    	File in = new File(CONFIG_XML);
+        FileInputStream input = new FileInputStream(in);
+        
+        // get input XML Document 
+        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance();
+        inputBuilderFactory.setIgnoringComments(true);
+        inputBuilderFactory.setCoalescing(true);
+        inputBuilderFactory.setIgnoringElementContentWhitespace(true);
+        inputBuilderFactory.setValidating(false);
+        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder();
+        Document inputDoc=inputBuilder.parse(input);
+        
+        // parse input XML Document
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        String expression = "/liberty-plugin-config/installAppPackages/text()";
+        String value = (String) xPath.compile(expression).evaluate(inputDoc, XPathConstants.STRING);
+        assertEquals("Value of <installAppPackages/> ==>", "project", value);
+    }
+    
+    @Test
+    public void testApplicationFileExist() throws Exception {
+        File f = new File("liberty/wlp/usr/servers/test/apps/SampleEAR.ear");
+        assertTrue(f.getCanonicalFile() + " doesn't exist", f.exists());
+    }
+}

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -47,7 +47,7 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
         boolean installDependencies = false;
         boolean installProject = false;
         
-        switch (installAppPackages) {
+        switch (getInstallAppPackages()) {
             case "all":
                 installDependencies = true;
                 installProject = true;

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -58,7 +58,7 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
      * Packages to install. One of "all", "dependencies" or "project".
      */
     @Parameter(property = "installAppPackages", defaultValue = "dependencies")
-    protected String installAppPackages;
+    private String installAppPackages;
     
     @Component
     private BuildContext buildContext;
@@ -71,6 +71,13 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         super.installServerAssembly();
         this.buildContext.refresh(f);
         this.buildContext.refresh(installDirectory);
+    }
+    
+    protected String getInstallAppPackages() {
+        if ("ear".equals(project.getPackaging())) {
+            installAppPackages = "project";
+        }
+        return installAppPackages;
     }
     
     /*
@@ -110,7 +117,7 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         configDocument.createElement("appsDirectory", getAppsDirectory());
         configDocument.createElement("looseApplication", looseApplication);
         configDocument.createElement("stripVersion", stripVersion);
-        configDocument.createElement("installAppPackages", installAppPackages);
+        configDocument.createElement("installAppPackages", getInstallAppPackages());
         configDocument.createElement("applicationFilename", getApplicationFilename());
         configDocument.createElement("assemblyArtifact", assemblyArtifact);   
         configDocument.createElement("assemblyArchive", assemblyArchive);
@@ -150,7 +157,7 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
      */
     protected String getApplicationFilename() {
         // A project doesn't build a web application artifact but getting the application artifacts from dependencies. e.g. liberty-assembly type project.
-        if (installAppPackages.equalsIgnoreCase("dependencies")) {
+        if ("dependencies".equals(getInstallAppPackages())) {
             return null;
         }
         


### PR DESCRIPTION
For a ear project, it includes EJB and WAR modules as a dependency to be packaged in the output ear file.  The installApps goal should not install the EJB or WAR modules dependency output into the liberty server apps location.  

installAppPackages configuration parameter value for a ear project will always be set to `project`