### PR TITLE
add skipLibertyPackage parameter for package-server

### DIFF
--- a/docs/package-server.md
+++ b/docs/package-server.md
@@ -13,6 +13,7 @@ The following are the parameters supported by this goal in addition to the [comm
 | packageFile | Location of the target file or directory. If the target location is a file, the contents of the server instance will be compressed into the specified file. If the target location is a directory, the contents of the server instance will be compressed into `${packageFile}/${project.build.finalName}.zip`&#124;`jar` file. If the target location is not specified, it defaults to `${project.build.directory}/${project.build.finalName}.zip`&#124;`jar`. A jar file is created when the packaging type is `runnable`. A zip file is created for other packaging types.| No |
 | include | Packaging type. Can be used with values `all`, `usr`, `minify`, `wlp`, `runnable`, `all,runnable`, and `minify,runnable`. The default value is `all`. The `runnable` value is supported beginning with 8.5.5.9 and works with `jar` type archives only.  | Yes, only when the `os` option is set |
 | os | A comma-delimited list of operating systems that you want the packaged server to support. To specify that an operating system is not to be supported, prefix it with a minus sign ("-"). The 'include' attribute __must__ be set to `minify`. | No |
+| skipLibertyPackage | If true, the `package-server` goal is bypassed entirely. The default value is false. | No |
 
 Examples:
 1. Package test server into a zip file.

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
@@ -60,9 +60,15 @@ public class PackageServerMojo extends StartDebugMojoSupport {
     @Parameter
     private boolean attach;
 
+    /**
+     * Skips this goal
+     */
+    @Parameter(property = "skipLibertyPackage", defaultValue = "false")
+    protected boolean skipLibertyPackage = false;
+    
     @Override
     protected void doExecute() throws Exception {
-        if (skip) {
+        if (skip || skipLibertyPackage) {
             return;
         }
         if (isInstall) {


### PR DESCRIPTION
We can call `mvn package -DskipLibertyPackage=true` to rebuild the project artifact while server is running.