### PR TITLE
Add missing manifest.mf in loose application

### DIFF
--- a/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/pom.xml
@@ -71,7 +71,7 @@
                     <serverName>test</serverName>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <appsDirectory>apps</appsDirectory>
-                    <looseApplication>false</looseApplication>
+                    <looseApplication>true</looseApplication>
                     <include>usr</include>
                 </configuration>
                 <executions>

--- a/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corporation 2017.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.wlp.maven.test.it;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Document;
+
+import static junit.framework.Assert.*;
+
+public class LooseConfigTestIT {
+    
+    public final String LOOSE_APP = "liberty/wlp/usr/servers/test/apps/SampleEAR.ear.xml";
+        
+    @Test
+    public void testLooseApplicationFileExist() throws Exception {
+        File f = new File(LOOSE_APP);
+        assertTrue(f.getCanonicalFile() + " doesn't exist", f.exists());
+    }
+    
+    @Test
+    public void testLooseApplicationFileContent() throws Exception {
+        File f = new File(LOOSE_APP);
+        FileInputStream input = new FileInputStream(f);
+        
+        // get input XML Document 
+        DocumentBuilderFactory inputBuilderFactory = DocumentBuilderFactory.newInstance();
+        inputBuilderFactory.setIgnoringComments(true);
+        inputBuilderFactory.setCoalescing(true);
+        inputBuilderFactory.setIgnoringElementContentWhitespace(true);
+        inputBuilderFactory.setValidating(false);
+        DocumentBuilder inputBuilder = inputBuilderFactory.newDocumentBuilder();
+        Document inputDoc=inputBuilder.parse(input);
+        
+        // parse input XML Document
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        String expression = "/archive/file";
+        NodeList nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        assertEquals("Number of <file/> element ==>", 2, nodes.getLength());
+        assertEquals("file targetInArchive attribute value", "/META-INF/application.xml", 
+                nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue());
+        assertEquals("file targetInArchive attribute value", "/META-INF/MANIFEST.MF", 
+                nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue());
+        
+        expression = "/archive/dir";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        assertEquals("Number of <dir/> element ==>", 1, nodes.getLength());
+        
+        expression = "/archive/archive";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        assertEquals("Number of <archive/> element ==>", 2, nodes.getLength());
+        assertEquals("archive targetInArchive attribute value", "/SampleEJB.jar", 
+                nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue());
+        assertEquals("archive targetInArchive attribute value", "/SampleWAR.war", 
+                nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue());
+    }
+}

--- a/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/PluginConfigXmlIT.java
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/PluginConfigXmlIT.java
@@ -57,10 +57,4 @@ public class PluginConfigXmlIT {
         File parentProj = new File("../..");
         assertEquals("Value of <aggregatorParentBasedir/> ==>", parentProj.getCanonicalPath(), value);
     }
-    
-    @Test
-    public void testApplicationFileExist() throws Exception {
-        File f = new File("liberty/wlp/usr/servers/test/apps/SampleEAR.ear");
-        assertTrue(f.getCanonicalFile() + " doesn't exist", f.exists());
-    }
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseApplication.java
@@ -1,0 +1,96 @@
+package net.wasdev.wlp.maven.plugins.applications;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.w3c.dom.Element;
+
+public class LooseApplication {
+    protected MavenProject project;
+    protected LooseConfigData config;
+    
+    public LooseApplication(MavenProject project, LooseConfigData config) {
+        this.project = project;
+        this.config = config;
+    }
+    
+    public LooseConfigData getConfig() {
+        return config;
+    }
+    
+    public Element getDocumentRoot() {
+        return config.getDocumentRoot();
+    }
+    
+    public Element addArchive(Element parent, String target) {
+        return config.addArchive(parent, target);
+    }
+    
+    public void addOutputDir(Element parent, MavenProject proj, String target) {
+        config.addDir(parent, proj.getBuild().getOutputDirectory(), target);
+    }
+    
+    public void addResourceDir(Element parent, MavenProject proj, String target) {
+        @SuppressWarnings("unchecked")
+        List<Resource> resources = proj.getResources();
+        for (Resource res : resources) {
+            config.addDir(parent, res.getDirectory(), target);
+        }
+    }
+    
+    public void addManifestFile(Element parent, MavenProject proj, String pluginId) throws Exception {
+        config.addFile(parent, getManifestFile(proj, "org.apache.maven.plugins", pluginId), "/META-INF/MANIFEST.MF");    
+    }
+    
+    public void addManifestFile(MavenProject proj, String pluginId) throws Exception {
+        config.addFile(getManifestFile(proj, "org.apache.maven.plugins", pluginId), "/META-INF/MANIFEST.MF"); 
+    }
+    
+    public String getPluginConfiguration(String pluginGroupId, String pluginArtifactId, String key) {
+        Xpp3Dom dom = project.getGoalConfiguration(pluginGroupId, pluginArtifactId, null, null);
+        if (dom != null) {
+            Xpp3Dom val = dom.getChild(key);
+            if (val != null) {
+                return val.getValue();
+            }
+        }
+        return null;
+    }
+    
+    public String getManifestFile(MavenProject proj, String pluginGroupId, String pluginArtifactId) throws Exception {
+        Xpp3Dom dom = proj.getGoalConfiguration(pluginGroupId, pluginArtifactId, null, null);
+        if (dom != null) {
+            Xpp3Dom archive = dom.getChild("archive");
+            if (archive != null) {
+                Xpp3Dom val = archive.getChild("manifestFile");
+                if (val != null) {
+                    return proj.getBasedir().getAbsolutePath() + "/" + val.getValue();
+                }
+            }
+        }
+        return getDefaultManifest().getCanonicalPath();
+    }
+    
+    private File defaultMF = null;
+    
+    public File getDefaultManifest() throws Exception {
+        if (defaultMF == null) {
+            defaultMF = new File(
+                    project.getBuild().getDirectory() + "/liberty-maven/resources/META-INF/MANIFEST.MF");
+            defaultMF.getParentFile().mkdirs();
+            FileOutputStream fos = new FileOutputStream(defaultMF);
+            
+            Manifest manifest = new Manifest();
+            manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+            manifest.write(fos);
+            fos.close();
+        }
+        return defaultMF;
+    }
+}

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseApplication.java
@@ -2,16 +2,16 @@ package net.wasdev.wlp.maven.plugins.applications;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.w3c.dom.Element;
 
 public class LooseApplication {
+    private File defaultMF = null;
+    
     protected MavenProject project;
     protected LooseConfigData config;
     
@@ -34,14 +34,6 @@ public class LooseApplication {
     
     public void addOutputDir(Element parent, MavenProject proj, String target) {
         config.addDir(parent, proj.getBuild().getOutputDirectory(), target);
-    }
-    
-    public void addResourceDir(Element parent, MavenProject proj, String target) {
-        @SuppressWarnings("unchecked")
-        List<Resource> resources = proj.getResources();
-        for (Resource res : resources) {
-            config.addDir(parent, res.getDirectory(), target);
-        }
     }
     
     public void addManifestFile(Element parent, MavenProject proj, String pluginId) throws Exception {
@@ -76,8 +68,6 @@ public class LooseApplication {
         }
         return getDefaultManifest().getCanonicalPath();
     }
-    
-    private File defaultMF = null;
     
     public File getDefaultManifest() throws Exception {
         if (defaultMF == null) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseConfigData.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseConfigData.java
@@ -71,6 +71,10 @@ public class LooseConfigData extends XmlDocument {
         writeXMLDocument(xmlFile);
     }
     
+    public Element getDocumentRoot() {
+        return doc.getDocumentElement();
+    }
+    
     private void addElement(Element parent, Element child, String targetAttr, String srcAttr) {
         child.setAttribute("sourceOnDisk", srcAttr);
         addElement(parent, child, targetAttr);

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
@@ -1,28 +1,13 @@
 package net.wasdev.wlp.maven.plugins.applications;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.util.List;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
-
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.w3c.dom.Element;
 
-public class LooseEarApplication {
-    private MavenProject project;
-    private LooseConfigData config;
+public class LooseEarApplication extends LooseApplication {
     
     public LooseEarApplication(MavenProject project, LooseConfigData config) {
-        this.project = project;
-        this.config = config;
-    }
-    
-    public LooseConfigData getConfig() {
-        return config;
+        super(project, config);
     }
     
     public Element addJarModule(MavenProject proj) throws Exception {
@@ -33,11 +18,7 @@ public class LooseEarApplication {
         }
         Element jarArchive = config.addArchive(jarArchiveName);
         config.addDir(jarArchive, proj.getBuild().getOutputDirectory(), "/");
-        @SuppressWarnings("unchecked")
-        List<Resource> resources = proj.getResources();
-        for (Resource res : resources) {
-            config.addDir(jarArchive, res.getDirectory(), "/");
-        }
+        addResourceDir(jarArchive, proj, "/");
         // add manifest.mf
         if ("ejb".equals(proj.getPackaging())) {
             addManifestFile(jarArchive, proj, "maven-ejb-plugin");
@@ -53,22 +34,10 @@ public class LooseEarApplication {
         Element warArchive = config.addArchive(warArchiveName);
         config.addDir(warArchive, warSourceDir, "/");
         config.addDir(warArchive, proj.getBuild().getOutputDirectory(), "/WEB-INF/classes");
-        @SuppressWarnings("unchecked")
-        List<Resource> resources = proj.getResources();
-        for (Resource res : resources) {
-            config.addDir(warArchive, res.getDirectory(), "/WEB-INF/classes");
-        }
+        addResourceDir(warArchive, proj, "/WEB-INF/classes");
         // add Manifest file
         addManifestFile(warArchive, proj, "maven-war-plugin");
         return warArchive;
-    }
-    
-    public void addManifestFile(Element e, MavenProject proj, String pluginId) throws Exception {
-        config.addFile(e, getManifestFile(proj, "org.apache.maven.plugins", pluginId), "/META-INF/MANIFEST.MF");    
-    }
-    
-    public void addManifestFile(MavenProject proj, String pluginId) throws Exception {
-        config.addFile(getManifestFile(proj, "org.apache.maven.plugins", pluginId), "/META-INF/MANIFEST.MF");    
     }
     
     public void addModuleFromM2(Artifact artifact, String artifactFile) {
@@ -125,47 +94,5 @@ public class LooseEarApplication {
     
     public String getEarDefaultLibBundleDir() {
         return getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "defaultLibBundleDir");
-    }
-    
-    public String getPluginConfiguration(String pluginGroupId, String pluginArtifactId, String key) {
-        Xpp3Dom dom = project.getGoalConfiguration(pluginGroupId, pluginArtifactId, null, null);
-        if (dom != null) {
-            Xpp3Dom val = dom.getChild(key);
-            if (val != null) {
-                return val.getValue();
-            }
-        }
-        return null;
-    }
-    
-    public String getManifestFile(MavenProject proj, String pluginGroupId, String pluginArtifactId) throws Exception {
-        Xpp3Dom dom = proj.getGoalConfiguration(pluginGroupId, pluginArtifactId, null, null);
-        if (dom != null) {
-            Xpp3Dom archive = dom.getChild("archive");
-            if (archive != null) {
-                Xpp3Dom val = archive.getChild("manifestFile");
-                if (val != null) {
-                    return proj.getBasedir().getAbsolutePath() + "/" + val.getValue();
-                }
-            }
-        }
-        return getDefaultManifest().getCanonicalPath();
-    }
-    
-    private File defaultMF = null;
-    
-    public File getDefaultManifest() throws Exception {
-        if (defaultMF == null) {
-            defaultMF = new File(
-                    project.getBuild().getDirectory() + "/liberty-maven/resources/META-INF/MANIFEST.MF");
-            defaultMF.getParentFile().mkdirs();
-            FileOutputStream fos = new FileOutputStream(defaultMF);
-            
-            Manifest manifest = new Manifest();
-            manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
-            manifest.write(fos);
-            fos.close();
-        }
-        return defaultMF;
     }
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseWarApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseWarApplication.java
@@ -1,10 +1,22 @@
 package net.wasdev.wlp.maven.plugins.applications;
 
+import java.io.File;
+
+
 import org.apache.maven.project.MavenProject;
 
 public class LooseWarApplication extends LooseApplication {
     
     public LooseWarApplication(MavenProject project, LooseConfigData config) {
         super(project, config);
+    }
+    
+    public void addSourceDir(MavenProject proj) throws Exception {
+        File sourceDir = new File(proj.getBasedir().getAbsolutePath(), "src/main/webapp");
+        String path = getPluginConfiguration("org.apache.maven.plugins", "maven-war-plugin", "warSourceDirectory");
+        if (path != null) {
+            sourceDir = new File(proj.getBasedir().getAbsolutePath(), path);
+        } 
+        config.addDir(sourceDir.getCanonicalPath(), "/");
     }
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseWarApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseWarApplication.java
@@ -1,0 +1,10 @@
+package net.wasdev.wlp.maven.plugins.applications;
+
+import org.apache.maven.project.MavenProject;
+
+public class LooseWarApplication extends LooseApplication {
+    
+    public LooseWarApplication(MavenProject project, LooseConfigData config) {
+        super(project, config);
+    }
+}

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -298,32 +298,9 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
     protected File getWarSourceDirectory(MavenProject proj) {
         String dir = getPluginConfiguration("org.apache.maven.plugins", "maven-war-plugin", "warSourceDirectory");
         if (dir != null) {
-            return new File(dir);
+            return new File(proj.getBasedir(), dir);
         } else {
-            return new File(proj.getBasedir() + "/src/main/webapp");
-        }
-    }
-    
-    protected File getEarSourceDirectory() {
-        String dir = getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "earSourceDirectory");
-        if (dir != null) {
-            return new File(dir);
-        } else {
-            return new File(project.getBasedir() + "/src/main/application");
-        }
-    }
-    
-    protected File getEarApplicationXml() {
-        log.debug("PluginConfigSupport:getEarApplicationXml() -> applicationXml=" + getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "applicationXml"));
-        log.debug("PluginConfigSupport:getEarApplicationXml() -> generateApplicationXml=" + getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "generateApplicationXml"));
-        String file = getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "applicationXml");
-        if (file != null && !file.isEmpty()) {
-            return new File(file);
-        } else if (getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "generateApplicationXml") == null || 
-                getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "generateApplicationXml").equals("true")) {
-            return new File(project.getBuild().getDirectory() + "/application.xml");
-        } else {
-            return null;
+            return new File(proj.getBasedir(), "src/main/webapp");
         }
     }
     
@@ -338,20 +315,6 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
     
     protected String getEarDefaultLibBundleDir() {
         return getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "defaultLibBundleDir");
-    }
-    
-    protected String getArchiveManifestFileConfig(MavenProject proj, String pluginGroupId, String pluginArtifactId) {
-        Xpp3Dom dom = proj.getGoalConfiguration(pluginGroupId, pluginArtifactId, null, null);
-        if (dom != null) {
-            Xpp3Dom archive = dom.getChild("archive");
-            if (archive != null) {
-                Xpp3Dom val = archive.getChild("manifestFile");
-                if (val != null) {
-                    return proj.getBasedir().getAbsolutePath() + "/" + val.getValue();
-                }
-            }
-        }
-        return null;
     }
     
     private String getPluginConfiguration(String pluginGroupId, String pluginArtifactId, String key) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -340,6 +340,20 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         return getPluginConfiguration("org.apache.maven.plugins", "maven-ear-plugin", "defaultLibBundleDir");
     }
     
+    protected String getArchiveManifestFileConfig(MavenProject proj, String pluginGroupId, String pluginArtifactId) {
+        Xpp3Dom dom = proj.getGoalConfiguration(pluginGroupId, pluginArtifactId, null, null);
+        if (dom != null) {
+            Xpp3Dom archive = dom.getChild("archive");
+            if (archive != null) {
+                Xpp3Dom val = archive.getChild("manifestFile");
+                if (val != null) {
+                    return proj.getBasedir().getAbsolutePath() + "/" + val.getValue();
+                }
+            }
+        }
+        return null;
+    }
+    
     private String getPluginConfiguration(String pluginGroupId, String pluginArtifactId, String key) {
         Xpp3Dom dom = project.getGoalConfiguration(pluginGroupId, pluginArtifactId, null, null);
         if (dom != null) {


### PR DESCRIPTION
- add missing default MANIFEST.MF in loose application xml file 
- redesign installLooseConfigWar() method to use maven project model to resolve sibling projects instead of relying on eclipse metadata
- fix minor error
- code refactoring