### PR TITLE
run package-server goal with running server

### DIFF
--- a/liberty-maven-app-parent/pom.xml
+++ b/liberty-maven-app-parent/pom.xml
@@ -79,6 +79,9 @@
                             <goals>
                                 <goal>package-server</goal>
                             </goals>
+                            <configuration>
+                                <outputDirectory>target/wlp-package</outputDirectory>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>test-start-server</id>


### PR DESCRIPTION
Use a different outputDirectory for package-server allows to be called with a running server started by start-server goal.