### PR TITLE
get transitive dependencies to loose application EAR

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -24,11 +24,12 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>plugin-support</artifactId>
             <version>1.0-alpha-1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>2.0.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-project</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
@@ -25,8 +25,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
-import org.apache.maven.project.ProjectBuildingException;
-import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.plugins.annotations.Component;
@@ -83,23 +81,22 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     @Parameter(property = "reactorProjects", required = true, readonly = true)
     protected List<MavenProject> reactorProjects;
     
-    protected boolean isReactorMavenProject(MavenProject proj) {
+    protected boolean isReactorMavenProject(Artifact artifact) {
         for (MavenProject p : reactorProjects) {
-            if (p.getGroupId().equals(proj.getGroupId()) && p.getArtifactId().equals(proj.getArtifactId())
-                    && p.getVersion().equals(proj.getVersion())) {
+            if (p.getGroupId().equals(artifact.getGroupId()) && p.getArtifactId().equals(artifact.getArtifactId())
+                    && p.getVersion().equals(artifact.getVersion())) {
                 return true;
             }
         }
         return false;
     }
     
-    protected MavenProject getMavenProject(String groupId, String artifactId, String version)
-            throws ProjectBuildingException {
-        
+    protected MavenProject getReactorMavenProject(Artifact artifact) {
         for (MavenProject p : reactorProjects) {
-            // Support loose configuration to all sub-module projects in the reactorProjects object. Need to be able to
-            // retrieve all transitive dependencies in these projects.
-            if (p.getGroupId().equals(groupId) && p.getArtifactId().equals(artifactId) && p.getVersion().equals(version)) {
+            // Support loose configuration to all sub-module projects in the reactorProjects object. 
+            // Need to be able to retrieve all transitive dependencies in these projects.
+            if (p.getGroupId().equals(artifact.getGroupId()) && p.getArtifactId().equals(artifact.getArtifactId())
+                    && p.getVersion().equals(artifact.getVersion())) {
                 p.setArtifactFilter(new ArtifactFilter() {
                     @Override
                     public boolean include(Artifact artifact) {
@@ -115,9 +112,6 @@ public abstract class AbstractLibertySupport extends MojoSupport {
             }
         }
         
-        // get project object that are not in the current reactor.
-        Artifact pomArtifact = repositorySystem.createProjectArtifact(groupId, artifactId, version);
-        ProjectBuildingResult build = mavenProjectBuilder.build(pomArtifact, session.getProjectBuildingRequest());
-        return build.getProject();
+        return null;
     }
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
@@ -64,6 +64,9 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     @Parameter(defaultValue = "${session}", readonly = true)
     protected MavenSession session;
     
+    @Parameter(property = "reactorProjects", required = true, readonly = true)
+    protected List<MavenProject> reactorProjects;
+    
     protected MavenProject getProject() {
         return project;
     }
@@ -77,9 +80,6 @@ public abstract class AbstractLibertySupport extends MojoSupport {
         // Initialize ant helper instance
         ant.setProject(getProject());
     }
-    
-    @Parameter(property = "reactorProjects", required = true, readonly = true)
-    protected List<MavenProject> reactorProjects;
     
     protected boolean isReactorMavenProject(Artifact artifact) {
         for (MavenProject p : reactorProjects) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
@@ -83,6 +83,16 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     @Parameter(property = "reactorProjects", required = true, readonly = true)
     protected List<MavenProject> reactorProjects;
     
+    protected boolean isReactorMavenProject(MavenProject proj) {
+        for (MavenProject p : reactorProjects) {
+            if (p.getGroupId().equals(proj.getGroupId()) && p.getArtifactId().equals(proj.getArtifactId())
+                    && p.getVersion().equals(proj.getVersion())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     protected MavenProject getMavenProject(String groupId, String artifactId, String version)
             throws ProjectBuildingException {
         

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
@@ -106,8 +106,6 @@ public abstract class AbstractLibertySupport extends MojoSupport {
                         return false;
                     }
                 });
-                log.debug("AbstractLibertySupport:getMavenProject() -> size of compile dependencies of "
-                        + p.getArtifactId() + " is " + p.getArtifacts().size());
                 return p;
             }
         }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
@@ -100,6 +100,9 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
         
         // proj is one of the reactor project and has compile dependency loaded.
         List<Dependency> deps = proj.getCompileDependencies();
+        log.debug("InstallAppsMojoSupport.installLooseConfigEars() -> No. of compile dependencies for " + proj.getArtifactId()
+                + " is " + deps.size());
+        
         for (Dependency dep : deps) {
             if ("compile".equals(dep.getScope())) {
                 MavenProject dependencyProject = getMavenProject(dep.getGroupId(), dep.getArtifactId(),
@@ -150,6 +153,8 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
     
     private void addEmbeddedLib(Element parent, MavenProject proj, LooseApplication looseApp, String dir) throws Exception {
         List<Dependency> deps = proj.getCompileDependencies();
+        log.debug("InstallAppsMojoSupport.addEmbeddedLib() -> No. of compile dependencies for " + proj.getArtifactId()
+                + " is " + deps.size());
         
         for (Dependency dep : deps) {
             if ("compile".equals(dep.getScope()) && "jar".equals(dep.getType())) {
@@ -160,6 +165,8 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
     
     private void addSkinnyWarLib(Element parent, MavenProject proj, LooseEarApplication looseEar) throws Exception {
         List<Dependency> deps = proj.getCompileDependencies();
+        log.debug("InstallAppsMojoSupport.addSkinnyWarLib() -> No. of compile dependencies for " + proj.getArtifactId()
+        + " is " + deps.size());
         
         for (Dependency dep : deps) {
             // skip the embedded library if it is included in the lib directory of the ear package

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
@@ -98,10 +98,8 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
         looseEar.addSourceDir();
         looseEar.addApplicationXmlFile();
         
-        // proj is one of the reactor project and has compile dependency loaded.
         Set<Artifact> artifacts = proj.getArtifacts();
-        log.debug("InstallAppsMojoSupport.installLooseConfigEars() -> No. of compile dependencies for " + proj.getArtifactId()
-                + " is " + artifacts.size());
+        log.debug("Number of compile dependencies for " + proj.getArtifactId() + " : " + artifacts.size());        
         
         for (Artifact artifact : artifacts) {
             if ("compile".equals(artifact.getScope())) {
@@ -150,42 +148,40 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
     }
     
     private void addEmbeddedLib(Element parent, MavenProject proj, LooseApplication looseApp, String dir) throws Exception {
-        Set<Artifact> deps = proj.getArtifacts();
-        log.debug("InstallAppsMojoSupport.addEmbeddedLib() -> No. of compile dependencies for " + proj.getArtifactId()
-                + " is " + deps.size());
+        Set<Artifact> artifacts = proj.getArtifacts();
+        log.debug("Number of compile dependencies for " + proj.getArtifactId() + " : " + artifacts.size());
         
-        for (Artifact dep : deps) {
-            if ("compile".equals(dep.getScope()) && "jar".equals(dep.getType())) {
-                addlibrary(parent, looseApp, dir, dep);
+        for (Artifact artifact : artifacts) {
+            if ("compile".equals(artifact.getScope()) && "jar".equals(artifact.getType())) {
+                addlibrary(parent, looseApp, dir, artifact);
             }
         }
     }
     
     private void addSkinnyWarLib(Element parent, MavenProject proj, LooseEarApplication looseEar) throws Exception {
-        Set<Artifact> deps = proj.getArtifacts();
-        log.debug("InstallAppsMojoSupport.addSkinnyWarLib() -> No. of compile dependencies for " + proj.getArtifactId()
-        + " is " + deps.size());
+        Set<Artifact> artifacts = proj.getArtifacts();
+        log.debug("Number of compile dependencies for " + proj.getArtifactId() + " : " + artifacts.size());
         
-        for (Artifact dep : deps) {
+        for (Artifact artifact : artifacts) {
             // skip the embedded library if it is included in the lib directory of the ear package
-            if ("compile".equals(dep.getScope()) && "jar".equals(dep.getType()) && !looseEar.isEarCompileDependency(dep)) {
-                addlibrary(parent, looseEar, "/WEB-INF/lib/", dep);
+            if ("compile".equals(artifact.getScope()) && "jar".equals(artifact.getType()) && !looseEar.isEarCompileDependency(artifact)) {
+                addlibrary(parent, looseEar, "/WEB-INF/lib/", artifact);
             }
         }
     }
     
-    private void addlibrary(Element parent, LooseApplication looseApp, String dir, Artifact dep)
+    private void addlibrary(Element parent, LooseApplication looseApp, String dir, Artifact artifact)
             throws Exception {
         {
-            if (isReactorMavenProject(dep)) {
-                MavenProject dependProject = getReactorMavenProject(dep);
+            if (isReactorMavenProject(artifact)) {
+                MavenProject dependProject = getReactorMavenProject(artifact);
                 Element archive = looseApp.addArchive(parent, dir + dependProject.getBuild().getFinalName() + ".jar");
                 looseApp.addOutputDir(archive, dependProject, "/");
                 looseApp.addManifestFile(archive, dependProject, "maven-jar-plugin");
             } else {
-                looseApp.getConfig().addFile(parent,
-                        resolveArtifact(dep).getFile().getAbsolutePath(),
-                        dir + resolveArtifact(dep).getFile().getName());
+                resolveArtifact(artifact);
+                looseApp.getConfig().addFile(parent, artifact.getFile().getAbsolutePath(),
+                        dir + artifact.getFile().getName());
             }
         }
     }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -85,8 +86,7 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
     
     private void installDependencies() throws Exception {
         Set<Artifact> artifacts = project.getArtifacts();
-        log.debug("InstallAppsMojo.installDependencies() -> No. of compile dependencies for " + project.getArtifactId()
-                + " is " + artifacts.size());
+        log.debug("Number of compile dependencies for " + project.getArtifactId() + " : " + artifacts.size());
         
         for (Artifact artifact : artifacts) {
             // skip if not an application type supported by Liberty

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -83,7 +83,7 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
     }
     
     private void installDependencies() throws Exception {
-        List<Dependency> deps = getProjectCompileDependencies(project);
+        List<Dependency> deps = project.getCompileDependencies();
         
         for (Dependency dep : deps) {
             // skip if not an application type supported by Liberty

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -84,6 +84,8 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
     
     private void installDependencies() throws Exception {
         List<Dependency> deps = project.getCompileDependencies();
+        log.debug("InstallAppsMojo.installDependencies() -> No. of compile dependencies for " + project.getArtifactId()
+                + " is " + deps.size());
         
         for (Dependency dep : deps) {
             // skip if not an application type supported by Liberty

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -98,7 +98,7 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
             }
             if (artifact.getScope().equals("compile")) {
                 if (isSupportedType(artifact.getType())) {
-                    if (isReactorMavenProject(artifact)) {
+                    if (looseApplication && isReactorMavenProject(artifact)) {
                         MavenProject dependProj = getReactorMavenProject(artifact);
                         installLooseApplication(dependProj);
                     } else {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -112,37 +112,6 @@ public class InstallAppsMojo extends InstallAppMojoSupport {
             }
         }
     }
-    /* TODO: remove this method
-    private void installDependencies_() throws Exception {
-        List<Dependency> deps = project.getCompileDependencies();
-        log.debug("InstallAppsMojo.installDependencies() -> No. of compile dependencies for " + project.getArtifactId()
-                + " is " + deps.size());
-        
-        for (Dependency dep : deps) {
-            // skip if not an application type supported by Liberty
-            if (!isSupportedType(dep.getType())) {
-                continue;
-            }
-            // skip assemblyArtifact if specified as a dependency
-            if (assemblyArtifact != null && matches(dep, assemblyArtifact)) {
-                continue;
-            }
-            if (dep.getScope().equals("compile")) {
-                MavenProject dependProj = getMavenProject(dep.getGroupId(), dep.getArtifactId(), dep.getVersion());
-                if (isSupportedType(dependProj.getPackaging())) {
-                    if (looseApplication && dependProj.getBasedir() != null && dependProj.getBasedir().exists()) {
-                        installLooseApplication(dependProj);
-                    } else {
-                        installApp(resolveArtifact(dependProj.getArtifact()));
-                    }
-                } else {
-                    log.warn(MessageFormat.format(messages.getString("error.application.not.supported"),
-                            project.getId()));
-                }
-            }
-        }
-    }
-    */
     
     protected void installProject() throws Exception {
         if (isSupportedType(project.getPackaging())) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
@@ -89,9 +89,11 @@ public class LooseEarApplication extends LooseApplication {
     public String getModuleUri(Artifact artifact) throws Exception {
         return getModuleUri(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(), artifact.getType()); 
     }
+    
     public String getModuleUri(MavenProject proj) throws Exception {
         return getModuleUri(proj.getGroupId(), proj.getArtifactId(), proj.getVersion(), proj.getPackaging()); 
     }
+    
     public String getModuleUri(String groupId, String artifactId, String version, String type) throws Exception {
         String defaultUri = "/" + getModuleName(groupId, artifactId, version, type);
         // both "jar" and "bundle" packaging type project are "jar" type dependencies that will be packaged in the ear lib directory
@@ -213,13 +215,14 @@ public class LooseEarApplication extends LooseApplication {
         }
     }
 
-    public boolean isEarCompileDependency(Artifact dependency) {
+    public boolean isEarCompileDependency(Artifact artifact) {
+        // get all ear project compile dependencies
         Set<Artifact> deps = project.getArtifacts();
         for (Artifact dep : deps) {
             if ("compile".equals(dep.getScope()) && "jar".equals(dep.getType()) 
-                    && dependency.getGroupId().equals(dep.getGroupId()) 
-                    && dependency.getArtifactId().equals(dep.getArtifactId())
-                    && dependency.getVersion().equals(dep.getVersion())) {
+                    && artifact.getGroupId().equals(dep.getGroupId()) 
+                    && artifact.getArtifactId().equals(dep.getArtifactId())
+                    && artifact.getVersion().equals(dep.getVersion())) {
                return true;
             }
         }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
@@ -211,10 +211,6 @@ public class LooseEarApplication extends LooseApplication {
     @SuppressWarnings("unchecked")
     public boolean isEarCompileDependency(Dependency dependency) {
         List<Dependency> deps = project.getCompileDependencies();
-        if (deps.size() == 0) {
-            // in case getCompileDependencies() is not returning any dependency (e.g multi-module ear project)
-            deps = project.getDependencies();
-        }
         for (Dependency dep : deps) {
             if ("compile".equals(dep.getScope()) && "jar".equals(dep.getType()) 
                     && dependency.getGroupId().equals(dep.getGroupId()) 

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CreateServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CreateServerMojo.java
@@ -19,6 +19,7 @@ import java.text.MessageFormat;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.plexus.util.FileUtils;
 
 import net.wasdev.wlp.ant.ServerTask;
@@ -26,7 +27,7 @@ import net.wasdev.wlp.ant.ServerTask;
 /**
  * Create a liberty server
   */
-@Mojo(name = "create-server") 
+@Mojo(name = "create-server", requiresDependencyResolution=ResolutionScope.COMPILE) 
 public class CreateServerMojo extends PluginConfigSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
@@ -16,11 +16,12 @@
 package net.wasdev.wlp.maven.plugins.server;
 
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Install a liberty server
  */
-@Mojo(name = "install-server")  
+@Mojo(name = "install-server", requiresDependencyResolution=ResolutionScope.COMPILE)  
 public class InstallServerMojo extends PluginConfigSupport {
     
     protected void doExecute() throws Exception {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -18,7 +18,9 @@ package net.wasdev.wlp.maven.plugins.server;
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.List;
+import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Profile;
 import org.apache.maven.plugins.annotations.Component;
@@ -134,12 +136,15 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
             configDocument.createElement("aggregatorParentBasedir", project.getParent().getBasedir());
         }
         
-        // output project compile dependencies
-        List<Dependency> deps = getProjectCompileDependencies(project);
-        for (Dependency dep : deps) {
-            if ("compile".equals(dep.getScope())) {
+        // Output project compile dependencies. 
+        // project.getArtifacts() will return all (including transitive) compile dependencies.
+        // if the mojo is set to COMIPLE dependencyScope.
+        Set<Artifact> artifacts = project.getArtifacts();
+        log.debug(this.getClass().getName() + " : number of compile dependencies is " + project.getArtifacts().size());
+        for (Artifact artifact : artifacts) {
+            if ("compile".equals(artifact.getScope())) {
                 configDocument.createElement("projectCompileDependency",
-                        dep.getGroupId() + ":" + dep.getArtifactId() + ":" + dep.getVersion());
+                        artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion());
             }
         }
         
@@ -320,7 +325,7 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         List<Dependency> deps = proj.getCompileDependencies();
         if (deps.size() == 0) {
             // in case getCompileDependencies() is not returning any dependency (e.g multi-module ear project)
-            log.debug("Unable to get compile dependency using getCompileDependencies() from project " + proj.getArtifactId());
+            log.info("TIU : " + "Unable to get compile dependency using getCompileDependencies() from project " + proj.getArtifactId());
             deps = proj.getDependencies();
         }
         

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -134,14 +134,9 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
             configDocument.createElement("aggregatorParentBasedir", project.getParent().getBasedir());
         }
         
-        // Output project compile dependencies. 
-        // project.getArtifacts() will return all (including transitive) compile dependencies.
-        // if the mojo is set to COMIPLE dependencyScope.
+        // returns all current project compile dependencies, including transitive dependencies
+        // if Mojo required dependencyScope is set to COMPILE
         Set<Artifact> artifacts = project.getArtifacts();
-        log.debug(this.getClass().getName() + " : number of compile dependencies is " + project.getArtifacts().size());
-        log.debug("PluginConfigSupport.exportParametersToXm() -> No. of compile dependencies for " + project.getArtifactId()
-        + " is " + artifacts.size());
-        
         for (Artifact artifact : artifacts) {
             if ("compile".equals(artifact.getScope())) {
                 configDocument.createElement("projectCompileDependency",

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Profile;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -90,7 +89,6 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
     protected File exportParametersToXml() throws Exception {
         PluginConfigXmlDocument configDocument = PluginConfigXmlDocument.newInstance("liberty-plugin-config");
         
-        @SuppressWarnings("unchecked")
         List<Profile> profiles = project.getActiveProfiles();
         configDocument.createActiveBuildProfilesElement("activeBuildProfiles", profiles);
         
@@ -318,22 +316,6 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         } else {
             return new File(proj.getBasedir(), "src/main/webapp");
         }
-    }
-    
-    @SuppressWarnings("unchecked")
-    protected List<Dependency> getProjectCompileDependencies(MavenProject proj) {
-        List<Dependency> deps = proj.getCompileDependencies();
-        if (deps.size() == 0) {
-            // in case getCompileDependencies() is not returning any dependency (e.g multi-module ear project)
-            log.info("TIU : " + "Unable to get compile dependency using getCompileDependencies() from project " + proj.getArtifactId());
-            deps = proj.getDependencies();
-        }
-        
-        //for (Dependency dep : deps) {
-        //    log.debug(dep.getArtifactId() + ":" + dep.getScope());
-        //}
-        
-        return deps;
     }
     
     private String getPluginConfiguration(MavenProject proj, String pluginGroupId, String pluginArtifactId, String key) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -139,6 +139,9 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         // if the mojo is set to COMIPLE dependencyScope.
         Set<Artifact> artifacts = project.getArtifacts();
         log.debug(this.getClass().getName() + " : number of compile dependencies is " + project.getArtifacts().size());
+        log.debug("PluginConfigSupport.exportParametersToXm() -> No. of compile dependencies for " + project.getArtifactId()
+        + " is " + artifacts.size());
+        
         for (Artifact artifact : artifacts) {
             if ("compile".equals(artifact.getScope())) {
                 configDocument.createElement("projectCompileDependency",


### PR DESCRIPTION
As suggested by @willlobato in issue #267:
- fix the maven-project dependency conflicts in the liberty-maven-plugin pom.xml file
- `getMavenProject()` method will be replaced by `getReactorMavenProject()` which will only return the multi-module projects object with transitive compile dependencies populated.
- refactoring the code not to use deprecated `getCompileDependencies()` method which will be replaced by `getArtifacts()` method