### PR TITLE
add runtime dependencies to loose Application

### DIFF
--- a/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/SampleEAR/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
@@ -76,5 +76,12 @@ public class LooseConfigTestIT {
                 nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue());
         assertEquals("archive targetInArchive attribute value", "/modules/web.war", 
                 nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue());
+        
+        expression = "/archive/archive/file";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        assertEquals("Number of <archive/> element ==>", 3, nodes.getLength());
+        // test runtime scope dependency to be incldued in the ?WEB-INF/lib
+        assertEquals("file targetInArchive attribute value", "/WEB-INF/lib/log4j-1.2.17.jar", 
+                nodes.item(2).getAttributes().getNamedItem("targetInArchive").getNodeValue());
     }
 }

--- a/liberty-maven-plugin/src/it/tests/ear-project-it/SampleWLP/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/SampleWLP/src/test/java/net/wasdev/wlp/maven/test/it/LooseConfigTestIT.java
@@ -76,5 +76,12 @@ public class LooseConfigTestIT {
                 nodes.item(0).getAttributes().getNamedItem("targetInArchive").getNodeValue());
         assertEquals("archive targetInArchive attribute value", "/modules/web.war", 
                 nodes.item(1).getAttributes().getNamedItem("targetInArchive").getNodeValue());
+        
+        expression = "/archive/archive/file";
+        nodes = (NodeList) xPath.compile(expression).evaluate(inputDoc, XPathConstants.NODESET);
+        assertEquals("Number of <archive/> element ==>", 3, nodes.getLength());
+        // test runtime scope dependency to be incldued in the ?WEB-INF/lib
+        assertEquals("file targetInArchive attribute value", "/WEB-INF/lib/log4j-1.2.17.jar", 
+                nodes.item(2).getAttributes().getNamedItem("targetInArchive").getNodeValue());
     }
 }

--- a/liberty-maven-plugin/src/it/tests/ear-project-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/ear-project-it/pom.xml
@@ -35,6 +35,7 @@
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>1.2.17</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>javax</groupId>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
@@ -100,7 +100,7 @@ public abstract class AbstractLibertySupport extends MojoSupport {
                 p.setArtifactFilter(new ArtifactFilter() {
                     @Override
                     public boolean include(Artifact artifact) {
-                        if ("compile".equals(artifact.getScope())) {
+                        if ("compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope())) {
                             return true;
                         }
                         return false;

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppMojoSupport.java
@@ -102,7 +102,7 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
         log.debug("Number of compile dependencies for " + proj.getArtifactId() + " : " + artifacts.size());        
         
         for (Artifact artifact : artifacts) {
-            if ("compile".equals(artifact.getScope())) {
+            if ("compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope())) {
                 if (!isReactorMavenProject(artifact)) {
                     if (looseEar.isEarSkinnyWars() && "war".equals(artifact.getType())) {
                         throw new MojoExecutionException(
@@ -152,7 +152,8 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
         log.debug("Number of compile dependencies for " + proj.getArtifactId() + " : " + artifacts.size());
         
         for (Artifact artifact : artifacts) {
-            if ("compile".equals(artifact.getScope()) && "jar".equals(artifact.getType())) {
+            if (("compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope()))
+                    && "jar".equals(artifact.getType())) {
                 addlibrary(parent, looseApp, dir, artifact);
             }
         }
@@ -164,7 +165,8 @@ public class InstallAppMojoSupport extends PluginConfigSupport {
         
         for (Artifact artifact : artifacts) {
             // skip the embedded library if it is included in the lib directory of the ear package
-            if ("compile".equals(artifact.getScope()) && "jar".equals(artifact.getType()) && !looseEar.isEarCompileDependency(artifact)) {
+            if (("compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope()))
+                    && "jar".equals(artifact.getType()) && !looseEar.isEarDependency(artifact)) {
                 addlibrary(parent, looseEar, "/WEB-INF/lib/", artifact);
             }
         }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -34,7 +34,7 @@ import net.wasdev.wlp.maven.plugins.ApplicationXmlDocument;
 /**
  * Copy applications to the specified directory of the Liberty server.
  */
-@Mojo(name = "install-apps", requiresDependencyResolution=ResolutionScope.COMPILE)
+@Mojo(name = "install-apps", requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class InstallAppsMojo extends InstallAppMojoSupport {
     
     protected void doExecute() throws Exception {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/LooseEarApplication.java
@@ -215,11 +215,12 @@ public class LooseEarApplication extends LooseApplication {
         }
     }
 
-    public boolean isEarCompileDependency(Artifact artifact) {
+    public boolean isEarDependency(Artifact artifact) {
         // get all ear project compile dependencies
         Set<Artifact> deps = project.getArtifacts();
         for (Artifact dep : deps) {
-            if ("compile".equals(dep.getScope()) && "jar".equals(dep.getType()) 
+            if (("compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope()))
+                    && "jar".equals(dep.getType()) 
                     && artifact.getGroupId().equals(dep.getGroupId()) 
                     && artifact.getArtifactId().equals(dep.getArtifactId())
                     && artifact.getVersion().equals(dep.getVersion())) {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CreateServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CreateServerMojo.java
@@ -27,7 +27,7 @@ import net.wasdev.wlp.ant.ServerTask;
 /**
  * Create a liberty server
   */
-@Mojo(name = "create-server", requiresDependencyResolution=ResolutionScope.COMPILE) 
+@Mojo(name = "create-server", requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME) 
 public class CreateServerMojo extends PluginConfigSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
@@ -21,7 +21,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Install a liberty server
  */
-@Mojo(name = "install-server", requiresDependencyResolution=ResolutionScope.COMPILE)  
+@Mojo(name = "install-server", requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)  
 public class InstallServerMojo extends PluginConfigSupport {
     
     protected void doExecute() throws Exception {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PluginConfigSupport.java
@@ -138,7 +138,7 @@ public class PluginConfigSupport extends StartDebugMojoSupport {
         // if Mojo required dependencyScope is set to COMPILE
         Set<Artifact> artifacts = project.getArtifacts();
         for (Artifact artifact : artifacts) {
-            if ("compile".equals(artifact.getScope())) {
+            if ("compile".equals(artifact.getScope()) || "runtime".equals(artifact.getScope())) {
                 configDocument.createElement("projectCompileDependency",
                         artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion());
             }


### PR DESCRIPTION
`runtime` scope dependencies are missing in the loose application file while they are included in the war and ear file by the Maven war and ear plugin.   