### PR TITLE
Fix issue with assemblyArtifact and appArtifact using version range

### DIFF
--- a/liberty-maven-plugin/pom.xml
+++ b/liberty-maven-plugin/pom.xml
@@ -29,6 +29,14 @@
                     <groupId>org.apache.maven</groupId>
                     <artifactId>maven-project</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-plugin-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/liberty-maven-plugin/src/it/tests/assembly-artifact-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/assembly-artifact-it/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.wasdev.wlp.maven.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>assembly-artifact-it</artifactId>
+    <packaging>pom</packaging>
+    
+    <dependencies>
+        <dependency>
+            <scope>provided</scope>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <configuration>
+                    <assemblyArtifact>
+                        <groupId>io.openliberty</groupId>
+                        <artifactId>openliberty-runtime</artifactId>
+                        <version>[17.0.0.0,)</version>
+                        <type>zip</type>
+                    </assemblyArtifact>
+                    <serverName>test</serverName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>install-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/tests/assembly-artifact-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/tests/assembly-artifact-it/src/test/resources/server.xml
@@ -1,0 +1,5 @@
+<server description="default server">
+    <featureManager>    
+        <feature>microProfile-1.2</feature>
+    </featureManager>     
+</server>

--- a/liberty-maven-plugin/src/it/tests/assembly-artifact-no-version-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/assembly-artifact-no-version-it/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.wasdev.wlp.maven.it</groupId>
+        <artifactId>tests</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>assembly-artifact-no-version-it</artifactId>
+    <packaging>pom</packaging>
+    
+    <dependencies>
+        <dependency>
+            <scope>provided</scope>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.openliberty</groupId>
+            <artifactId>openliberty-runtime</artifactId>
+            <version>[17.0.0.0,)</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.wasdev.wlp.maven.plugins</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <configuration>
+                    <assemblyArtifact>
+                        <groupId>io.openliberty</groupId>
+                        <artifactId>openliberty-runtime</artifactId>
+                        <type>zip</type>
+                    </assemblyArtifact>
+                    <serverName>test</serverName>
+                    <appArtifact>
+                        <groupId>net.wasdev.wlp.maven.it</groupId>
+                        <artifactId>test-war</artifactId>
+                        <version>[0.0,)</version>
+                        <type>war</type>
+                    </appArtifact>
+                    <serverName>test</serverName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>start-server</goal>
+                            <goal>deploy</goal>
+                            <goal>stop-server</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/liberty-maven-plugin/src/it/tests/assembly-artifact-no-version-it/src/test/resources/server.xml
+++ b/liberty-maven-plugin/src/it/tests/assembly-artifact-no-version-it/src/test/resources/server.xml
@@ -1,0 +1,5 @@
+<server description="default server">
+    <featureManager>    
+        <feature>microProfile-1.0</feature>
+    </featureManager>     
+</server>

--- a/liberty-maven-plugin/src/it/tests/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/pom.xml
@@ -19,6 +19,8 @@
         <module>test-assembly</module>
         <module>assembly-it</module>
         <module>basic-it</module>
+        <module>assembly-artifact-it</module>
+        <module>assembly-artifact-no-version-it</module>
         <module>ear-project-it</module>
         <module>install-features-it</module>
         <module>install-apps-project-it</module>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/AbstractLibertySupport.java
@@ -239,18 +239,20 @@ public abstract class AbstractLibertySupport extends MojoSupport {
     }
     
     private Dependency resolveFromProjectDepMgmt(ArtifactItem item) {
-        List<Dependency> list = getProject().getDependencyManagement().getDependencies();
-        
-        for (Dependency dependency : list) {
-            if (dependency.getGroupId().equals(item.getGroupId())
-                    && dependency.getArtifactId().equals(item.getArtifactId())
-                    && dependency.getType().equals(item.getType())) {
-                log.debug("Found ArtifactItem from project dependencyManagement " + dependency.getGroupId() + ":"
-                        + dependency.getArtifactId() + ":" + dependency.getVersion());
-                return dependency;
+        // if project has dependencyManagement section
+        if (getProject().getDependencyManagement() != null) {
+            List<Dependency> list = getProject().getDependencyManagement().getDependencies();
+            
+            for (Dependency dependency : list) {
+                if (dependency.getGroupId().equals(item.getGroupId())
+                        && dependency.getArtifactId().equals(item.getArtifactId())
+                        && dependency.getType().equals(item.getType())) {
+                    log.debug("Found ArtifactItem from project dependencyManagement " + dependency.getGroupId() + ":"
+                            + dependency.getArtifactId() + ":" + dependency.getVersion());
+                    return dependency;
+                }
             }
         }
-        
         log.debug(item.getGroupId() + ":" + item.getArtifactId() + ":" + item.getVersion()
                 + " is not found from project dependencyManagement.");
         return null;

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DeployAppMojo.java
@@ -22,6 +22,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
 
 import net.wasdev.wlp.ant.DeployTask;
@@ -30,7 +31,7 @@ import net.wasdev.wlp.maven.plugins.BasicSupport;
 /**
  * Deploy application to liberty server
  */
-@Mojo(name = "deploy")
+@Mojo(name = "deploy", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class DeployAppMojo extends BasicSupport {
     /**
      * A file which points to a specific module's war | ear | eba | zip archive location

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DisplayUrlMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/DisplayUrlMojo.java
@@ -16,18 +16,19 @@
 package net.wasdev.wlp.maven.plugins.applications;
 
 import java.awt.Desktop;
-
+import java.io.IOException;
 import java.net.URI;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import net.wasdev.wlp.maven.plugins.BasicSupport;
 
 /**
  * Display an application URL in the default browser.
  */
 @Mojo(name = "display-url")
-public class DisplayUrlMojo extends BasicSupport {
+public class DisplayUrlMojo extends AbstractMojo {
     
     /**
      * Display a URI in the default browser
@@ -35,10 +36,13 @@ public class DisplayUrlMojo extends BasicSupport {
     @Parameter
     protected URI applicationURL;
  
-    @Override
-    protected void doExecute() throws Exception {
+    public void execute() throws MojoExecutionException {
         if (applicationURL != null && Desktop.isDesktopSupported()) {
-            Desktop.getDesktop().browse(applicationURL);
+            try {
+                Desktop.getDesktop().browse(applicationURL);
+            } catch (IOException e) {
+                throw new MojoExecutionException(e.getLocalizedMessage(), e);
+            }
         }
     }
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/InstallAppsMojo.java
@@ -34,7 +34,7 @@ import net.wasdev.wlp.maven.plugins.ApplicationXmlDocument;
 /**
  * Copy applications to the specified directory of the Liberty server.
  */
-@Mojo(name = "install-apps", requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)
+@Mojo(name = "install-apps", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class InstallAppsMojo extends InstallAppMojoSupport {
     
     protected void doExecute() throws Exception {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/UndeployAppMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/applications/UndeployAppMojo.java
@@ -23,7 +23,7 @@ import net.wasdev.wlp.ant.UndeployTask;
 import net.wasdev.wlp.maven.plugins.BasicSupport;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.tools.ant.types.PatternSet;
@@ -33,7 +33,7 @@ import org.codehaus.mojo.pluginsupport.util.ArtifactItem;
  * Undeploy application from liberty server. If no parameters have been defined
  * the mojo will undeploy all applications from the server.
  */
-@Mojo(name = "undeploy")
+@Mojo(name = "undeploy", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 
 public class UndeployAppMojo extends BasicSupport {
     

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CheckStatusMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CheckStatusMojo.java
@@ -19,11 +19,12 @@ import java.text.MessageFormat;
 
 import net.wasdev.wlp.ant.ServerTask;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Check a liberty server status
  */
-@Mojo(name = "server-status")
+@Mojo(name = "server-status", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class CheckStatusMojo extends StartDebugMojoSupport {
 
     protected void doExecute() throws Exception {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CleanServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CleanServerMojo.java
@@ -18,11 +18,12 @@ package net.wasdev.wlp.maven.plugins.server;
 import net.wasdev.wlp.ant.CleanTask;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Clean the logs, workarea, dropins and apps directories.
  */
-@Mojo(name = "clean-server")
+@Mojo(name = "clean-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class CleanServerMojo extends StartDebugMojoSupport {
     
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CreateServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/CreateServerMojo.java
@@ -27,7 +27,7 @@ import net.wasdev.wlp.ant.ServerTask;
 /**
  * Create a liberty server
   */
-@Mojo(name = "create-server", requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME) 
+@Mojo(name = "create-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 public class CreateServerMojo extends PluginConfigSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DebugServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DebugServerMojo.java
@@ -19,13 +19,14 @@ import java.text.MessageFormat;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import net.wasdev.wlp.ant.ServerTask;
 
 /**
  * Start a liberty server in debug mode
  */
-@Mojo(name = "debug-server") 
+@Mojo(name = "debug-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 
 public class DebugServerMojo extends StartDebugMojoSupport {
 

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DumpServerMojo.java
@@ -21,11 +21,12 @@ import java.text.MessageFormat;
 import net.wasdev.wlp.ant.ServerTask;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Dump diagnostic information from the server into an archive.
   */
-@Mojo(name = "dump-server")
+@Mojo(name = "dump-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class DumpServerMojo extends StartDebugMojoSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallFeatureMojo.java
@@ -23,12 +23,13 @@ import java.text.MessageFormat;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * This mojo installs a feature packaged as a Subsystem Archive (esa) to the
  * runtime.
  */
-@Mojo(name = "install-feature") 
+@Mojo(name = "install-feature", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 public class InstallFeatureMojo extends BasicSupport {
     
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
@@ -21,7 +21,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Install a liberty server
  */
-@Mojo(name = "install-server", requiresDependencyResolution=ResolutionScope.COMPILE_PLUS_RUNTIME)  
+@Mojo(name = "install-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)  
 public class InstallServerMojo extends PluginConfigSupport {
     
     protected void doExecute() throws Exception {

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/JavaDumpServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/JavaDumpServerMojo.java
@@ -20,11 +20,12 @@ import java.text.MessageFormat;
 import net.wasdev.wlp.ant.ServerTask;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Dump diagnostic information from the server JVM.
  */
-@Mojo(name = "java-dump-server") 
+@Mojo(name = "java-dump-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 public class JavaDumpServerMojo extends StartDebugMojoSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/PackageServerMojo.java
@@ -22,13 +22,15 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import net.wasdev.wlp.ant.ServerTask;
 
 /**
  * Package a liberty server
  */
-@Mojo(name = "package-server", defaultPhase = LifecyclePhase.PACKAGE) 
+@Mojo(name = "package-server", defaultPhase = LifecyclePhase.PACKAGE,
+      requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 public class PackageServerMojo extends StartDebugMojoSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/RunServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/RunServerMojo.java
@@ -18,13 +18,14 @@ package net.wasdev.wlp.maven.plugins.server;
 import java.text.MessageFormat;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import net.wasdev.wlp.ant.ServerTask;
 
 /**
  * Start a liberty server
  */
-@Mojo(name = "run-server") 
+@Mojo(name = "run-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 public class RunServerMojo extends StartDebugMojoSupport {
 
     /**

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StartServerMojo.java
@@ -20,13 +20,14 @@ import java.text.MessageFormat;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import net.wasdev.wlp.ant.ServerTask;
 
 /**
  * Start a liberty server
  */
-@Mojo(name = "start-server") 
+@Mojo(name = "start-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 
 public class StartServerMojo extends StartDebugMojoSupport {
 

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/StopServerMojo.java
@@ -20,11 +20,12 @@ import java.text.MessageFormat;
 import net.wasdev.wlp.ant.ServerTask;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Stop a liberty server
  */
-@Mojo(name = "stop-server") 
+@Mojo(name = "stop-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 public class StopServerMojo extends StartDebugMojoSupport {
 
     @Override

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/TestStartServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/TestStartServerMojo.java
@@ -17,11 +17,12 @@ package net.wasdev.wlp.maven.plugins.server;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Start a liberty server if tests are not skipped
  */
-@Mojo(name = "test-start-server") 
+@Mojo(name = "test-start-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 
 public class TestStartServerMojo extends StartServerMojo {
     

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/TestStopServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/TestStopServerMojo.java
@@ -17,11 +17,12 @@ package net.wasdev.wlp.maven.plugins.server;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Quickly bypass stopping server if server isn't started
  */
-@Mojo(name = "test-stop-server") 
+@Mojo(name = "test-stop-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 
 public class TestStopServerMojo extends StopServerMojo {
     

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/UninstallFeatureMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/UninstallFeatureMojo.java
@@ -25,12 +25,13 @@ import org.apache.maven.plugin.MojoExecutionException;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * This mojo uninstalls a feature packaged as a Subsystem Archive (esa) from the
  * runtime.
  */
-@Mojo(name = "uninstall-feature") 
+@Mojo(name = "uninstall-feature", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME) 
 
 public class UninstallFeatureMojo extends BasicSupport {
     


### PR DESCRIPTION
- [x] clean up Maven 2 dependencies in liberty-maven-plugin/pom.xml
- [x] override org.codehaus.mojo.pluginsupport.MojoSupport methods to resolve and create artifact from ArtifactItem using Apache Maven Artifact Resolver (http://maven.apache.org/resolver/index.html)
- [x] add requiresDependencyResolution to @Mojo annotation so that Maven 3 runtime will retreive the project dependencies and make them available to the mojo
- [x] add testcase.