### PR TITLE
Fix install-feature configuration in parent pom

### DIFF
--- a/liberty-maven-app-parent/pom.xml
+++ b/liberty-maven-app-parent/pom.xml
@@ -73,6 +73,9 @@
                             <goals>
                               <goal>install-feature</goal>
                             </goals>
+                            <configuration>
+                                <outputDirectory>target/liberty-alt-output-dir</outputDirectory>
+                            </configuration>
                         </execution>
                         <execution>
                             <id>install-apps</id>
@@ -88,7 +91,7 @@
                                 <goal>package-server</goal>
                             </goals>
                             <configuration>
-                                <outputDirectory>target/wlp-package</outputDirectory>
+                                <outputDirectory>target/liberty-alt-output-dir</outputDirectory>
                             </configuration>
                         </execution>
                         <execution>


### PR DESCRIPTION
If install-feature shares the same outputDirectory as start-server, install-feature can't be called with running server.