### PR TITLE
Build test Open Liberty 18.0.0.2 kernel from runtime

### DIFF
--- a/liberty-maven-plugin/src/it/setup/openliberty-kernel/pom.xml
+++ b/liberty-maven-plugin/src/it/setup/openliberty-kernel/pom.xml
@@ -9,7 +9,7 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <!-- Create an openliberty kernel zip from the opneliberty development dirver -->
+    <!-- Create an openliberty kernel zip from the openliberty runtime -->
     <!-- Remove this project when the openliberty-kernel-18.0.0.x is available in maven central -->
 
     <artifactId>openliberty-kernel</artifactId>
@@ -18,33 +18,18 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>wagon-maven-plugin</artifactId>
-                <version>1.0</version>
-                <executions>
-                    <execution>
-                        <id>download-ol-development-driver</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
-                        <configuration>
-                           <serverId>dhe</serverId>
-                           <url>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/2018-06-12_0629/</url>
-                           <fromFile>openliberty-all-20180612-0500.zip</fromFile>
-                           <toFile>target/openliberty-all.zip</toFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Enable liberty-maven-plugin -->
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <assemblyArchive>target/openliberty-all.zip</assemblyArchive>
+                    <assemblyArtifact>
+                        <groupId>io.openliberty</groupId>
+                        <artifactId>openliberty-runtime</artifactId>
+                        <version>18.0.0.2</version>
+                        <type>zip</type>
+                    </assemblyArtifact>
                     <configFile>src/main/liberty/config/server.xml</configFile>
                     <serverName>dummy</serverName>
                     <include>minify</include>


### PR DESCRIPTION
For the Open Liberty 18.0.0.2 kernel which is used for install feature integration tests, build it from the runtime zip instead of the development driver.