### PR TITLE
Remove Spring Boot parent module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
 
     <modules>
         <module>liberty-maven-app-parent</module>
-        <module>liberty-spring-boot-parent</module>
         <module>liberty-maven-plugin</module>
         <module>liberty-plugin-archetype</module>
         <module>liberty-archetype-webapp</module>


### PR DESCRIPTION
Removing this module as it can't use the Liberty Maven parent, so we cannot release it. 