### PR TITLE
Move test ci.common dependency to v1.2.1

### DIFF
--- a/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
+++ b/liberty-maven-plugin/src/it/arquillian-tests/pom.xml
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>net.wasdev.wlp.common</groupId>
 			<artifactId>ci.common</artifactId>
-			<version>1.3-SNAPSHOT</version>
+			<version>1.2.1</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
There is no 1.3-SNAPSHOT, so this doesn't work.