### PR TITLE
Add feature to specify liberty settings folder

### DIFF
--- a/docs/create-server.md
+++ b/docs/create-server.md
@@ -9,6 +9,7 @@ The following are the parameters supported by this goal in addition to the [comm
 | Parameter | Description | Required |
 | --------  | ----------- | -------  |
 | template | Name of the template to use when creating a new server. | No |
+| libertySettingsFolder | Path to directory containing liberty configuration files. | No |
 
 Example:
 ```xml

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/pom.xml
@@ -76,6 +76,7 @@
           <serverName>test</serverName>
           <installAppPackages>project</installAppPackages>
           <configDirectory>src/test/resources/testConfig</configDirectory>
+          <libertySettingsFolder>${project.basedir}/src/test/resources/testLibertyConfig</libertySettingsFolder>
         </configuration>
         <executions>
             <execution>

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/pom.xml
@@ -87,38 +87,6 @@
                 </goals>
             </execution>
             <execution>
-                <id>install-artifact</id>
-                <phase>package</phase>
-                <goals>
-                    <goal>install-apps</goal>
-                </goals>
-            </execution>
-            <execution>
-               <id>start-liberty-server</id>
-               <phase>pre-integration-test</phase>
-               <goals>
-                   <goal>start-server</goal>
-               </goals>
-               <configuration>
-                   <background>true</background>
-                   <verifyTimeout>40</verifyTimeout>
-               </configuration>
-            </execution>
-            <execution>
-               <id>check-liberty-server</id>
-               <phase>pre-integration-test</phase>
-               <goals>
-                   <goal>server-status</goal>
-               </goals>
-            </execution>
-            <execution>
-                <id>stop-liberty-server</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                    <goal>stop-server</goal>
-                </goals>
-            </execution>
-            <execution>
                 <id>clean-server</id>
                 <phase>post-integration-test</phase>
                 <goals>

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/pom.xml
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/pom.xml
@@ -116,6 +116,9 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
+                    <systemPropertyVariables>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/java/net/wasdev/wlp/maven/test/app/LibertySettingsDirectoryTest.java
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/java/net/wasdev/wlp/maven/test/app/LibertySettingsDirectoryTest.java
@@ -13,8 +13,6 @@ import org.apache.maven.shared.invoker.InvocationOutputHandler;
 import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
-import org.apache.maven.shared.invoker.MavenInvocationException;
-
 
 /**
  * 
@@ -33,12 +31,10 @@ public class LibertySettingsDirectoryTest {
     
     @Test
     public void testLibertyConfigDirInvalidDir() throws Exception {
-        File mavenHome = new File("/usr/local/Cellar/maven/3.5.4/libexec");
 
         InvocationRequest request = new DefaultInvocationRequest();
         request.setPomFile( new File("../src/test/resources/invalidDirPom.xml"));
         request.setGoals( Collections.singletonList("package"));
-        // request.setShellEnvironmentInherited(true);
 
         InvocationOutputHandler outputHandler = new InvocationOutputHandler(){
             @Override
@@ -51,14 +47,10 @@ public class LibertySettingsDirectoryTest {
 
         Invoker invoker = new DefaultInvoker();
         invoker.setOutputHandler(outputHandler);
-        invoker.setMavenHome(mavenHome);
-        try {
-            InvocationResult result = invoker.execute( request );
 
-            assertTrue("Exited successfully, expected non-zero exit code.", result.getExitCode() != 0);
-            assertNotNull("Expected Exception to be thrown.", result.getExecutionException());
-        } catch (MavenInvocationException e) {
-            e.printStackTrace();
-        }
+        InvocationResult result = invoker.execute( request );
+
+        assertTrue("Exited successfully, expected non-zero exit code.", result.getExitCode() != 0);
+        assertNotNull("Expected Exception to be thrown.", result.getExecutionException());
     }
 }

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/java/net/wasdev/wlp/maven/test/app/LibertySettingsDirectoryTest.java
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/java/net/wasdev/wlp/maven/test/app/LibertySettingsDirectoryTest.java
@@ -3,7 +3,18 @@ package net.wasdev.wlp.maven.test.app;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
 import org.junit.Test;
+
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationOutputHandler;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+
 
 /**
  * 
@@ -17,5 +28,37 @@ public class LibertySettingsDirectoryTest {
     public void testLibertyConfigDirValidDir() throws Exception {
         File f1 = new File("liberty/etc", "repository.properties");
         assertTrue(f1.getCanonicalFile() + " doesn't exist", f1.exists());
+    }
+
+    
+    @Test
+    public void testLibertyConfigDirInvalidDir() throws Exception {
+        File mavenHome = new File("/usr/local/Cellar/maven/3.5.4/libexec");
+
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile( new File("../src/test/resources/invalidDirPom.xml"));
+        request.setGoals( Collections.singletonList("package"));
+        // request.setShellEnvironmentInherited(true);
+
+        InvocationOutputHandler outputHandler = new InvocationOutputHandler(){
+            @Override
+            public void consumeLine(String line) throws IOException {
+                if (line.contains("<libertySettingsFolder> must be a directory")) {
+                    throw new IOException("Caught expected MojoExecutionException - " + line);
+                }
+            }
+        };
+
+        Invoker invoker = new DefaultInvoker();
+        invoker.setOutputHandler(outputHandler);
+        invoker.setMavenHome(mavenHome);
+        try {
+            InvocationResult result = invoker.execute( request );
+
+            assertTrue("Exited successfully, expected non-zero exit code.", result.getExitCode() != 0);
+            assertNotNull("Expected Exception to be thrown.", result.getExecutionException());
+        } catch (MavenInvocationException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/java/net/wasdev/wlp/maven/test/app/LibertySettingsDirectoryTest.java
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/java/net/wasdev/wlp/maven/test/app/LibertySettingsDirectoryTest.java
@@ -1,0 +1,21 @@
+package net.wasdev.wlp.maven.test.app;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import org.junit.Test;
+
+/**
+ * 
+ * configDirectory test case
+ * 
+ */
+
+public class LibertySettingsDirectoryTest {
+
+    @Test
+    public void testLibertyConfigDirValidDir() throws Exception {
+        File f1 = new File("liberty/etc", "repository.properties");
+        assertTrue(f1.getCanonicalFile() + " doesn't exist", f1.exists());
+    }
+}

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/resources/invalidDirPom.xml
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/resources/invalidDirPom.xml
@@ -12,27 +12,6 @@
   <artifactId>config-directory-it</artifactId>
   <packaging>war</packaging>
 
-  <dependencies>
-    <dependency>
-        <groupId>org.apache.geronimo.specs</groupId>
-        <artifactId>geronimo-servlet_3.0_spec</artifactId>
-        <version>1.0</version>
-        <scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>1.0.4</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.9</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  
   <build>
     <pluginManagement>
         <plugins>
@@ -40,16 +19,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.3</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.5</version>
             </plugin>
         </plugins>
     </pluginManagement>
@@ -63,7 +32,7 @@
       <plugin>
         <groupId>net.wasdev.wlp.maven.plugins</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>@pom.version@</version>
+        <version>${pluginVersion}</version>
         <extensions>true</extensions>
         <configuration>
           <stripVersion>true</stripVersion>
@@ -86,55 +55,8 @@
                     <goal>create-server</goal>
                 </goals>
             </execution>
-            <execution>
-                <id>clean-server</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                    <goal>clean-server</goal>
-                </goals>
-                <configuration>
-                    <cleanDropins>true</cleanDropins>
-                    <cleanApps>true</cleanApps>
-                </configuration>
-            </execution>
          </executions>
        </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <forkMode>once</forkMode>
-                    <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
-                    <argLine>-enableassertions</argLine>
-                    <workingDirectory>${project.build.directory}</workingDirectory>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>integration-test</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>verify</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
     </plugins>
   </build>
 </project>

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/resources/invalidDirPom.xml
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/resources/invalidDirPom.xml
@@ -26,15 +26,10 @@
         <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.9</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.maven.shared</groupId>
-        <artifactId>maven-invoker</artifactId>
-        <version>3.0.1</version>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.9</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   
@@ -81,7 +76,7 @@
           <serverName>test</serverName>
           <installAppPackages>project</installAppPackages>
           <configDirectory>src/test/resources/testConfig</configDirectory>
-          <libertySettingsFolder>${project.basedir}/src/test/resources/testLibertyConfig</libertySettingsFolder>
+          <libertySettingsFolder>${project.basedir}/src/test/resources/testLibertyConfig/repository.properties</libertySettingsFolder>
         </configuration>
         <executions>
             <execution>

--- a/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/resources/invalidDirPom.xml
+++ b/liberty-maven-plugin/src/it/tests/config-directory-it/src/test/resources/invalidDirPom.xml
@@ -76,7 +76,7 @@
           <serverName>test</serverName>
           <installAppPackages>project</installAppPackages>
           <configDirectory>src/test/resources/testConfig</configDirectory>
-          <libertySettingsFolder>${project.basedir}/src/test/resources/testLibertyConfig/repository.properties</libertySettingsFolder>
+          <libertySettingsFolder>${project.basedir}/testLibertyConfig/repository.properties</libertySettingsFolder>
         </configuration>
         <executions>
             <execution>

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
@@ -42,7 +42,6 @@ public class InstallServerMojo extends PluginConfigSupport {
         if (skip) {
             return;
         }
-        log.info(MessageFormat.format(messages.getString("info.variable.set"), "libertySettingsFolder", libertySettingsFolder));
 
         copyLibertySettings();
 
@@ -50,23 +49,28 @@ public class InstallServerMojo extends PluginConfigSupport {
     }
 
     private void copyLibertySettings() throws MojoExecutionException, IOException {
-        if (libertySettingsFolder.isDirectory()) {
+        if (libertySettingsFolder.exists()) {
+            if (!libertySettingsFolder.isDirectory()) {
+                throw new MojoExecutionException("The Liberty configuration <libertySettingsFolder> must be a directory. Value found: " + libertySettingsFolder.toString());
+            }
+
+            log.info(MessageFormat.format(messages.getString("info.variable.set"), "libertySettingsFolder", libertySettingsFolder));
+
+            // copy config files to <install directory>/etc
             File[] files = libertySettingsFolder.listFiles();
             if (files != null && files.length > 0) {
                 File installDir = new File(installDirectory + "/etc");
-
                 if (!installDir.exists()) {
                     installDir.mkdirs();
                 }
 
                 log.info("Copying " + files.length + " file" + ((files.length == 1) ? "":"s") + " to " + installDir.getCanonicalPath());
-
                 FileUtils.copyDirectory(libertySettingsFolder, installDir);
             } else {
                 log.info("No custom Liberty configuration files found.");
             }
         } else {
-            throw new MojoExecutionException("The Liberty configuration <libertySettingsFolder> must be an existing directory. Value found: " + libertySettingsFolder.toString());
+            log.debug("No custom Liberty configuration folder found.");
         }
     }
 }

--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/InstallServerMojo.java
@@ -15,14 +15,7 @@
  */
 package net.wasdev.wlp.maven.plugins.server;
 
-import java.io.File;
-import java.io.IOException;
-import java.text.MessageFormat;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
@@ -31,46 +24,12 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(name = "install-server", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class InstallServerMojo extends PluginConfigSupport {
 
-    /**
-     * Directory of custom configuration files
-     */
-    @Parameter(property = "libertySettingsFolder", defaultValue = "${basedir}/src/main/resources/etc")
-    private File libertySettingsFolder;
-
     @Override
     protected void doExecute() throws Exception {
         if (skip) {
             return;
         }
 
-        copyLibertySettings();
-
         installServerAssembly();
-    }
-
-    private void copyLibertySettings() throws MojoExecutionException, IOException {
-        if (libertySettingsFolder.exists()) {
-            if (!libertySettingsFolder.isDirectory()) {
-                throw new MojoExecutionException("The Liberty configuration <libertySettingsFolder> must be a directory. Value found: " + libertySettingsFolder.toString());
-            }
-
-            log.info(MessageFormat.format(messages.getString("info.variable.set"), "libertySettingsFolder", libertySettingsFolder));
-
-            // copy config files to <install directory>/etc
-            File[] files = libertySettingsFolder.listFiles();
-            if (files != null && files.length > 0) {
-                File installDir = new File(installDirectory + "/etc");
-                if (!installDir.exists()) {
-                    installDir.mkdirs();
-                }
-
-                log.info("Copying " + files.length + " file" + ((files.length == 1) ? "":"s") + " to " + installDir.getCanonicalPath());
-                FileUtils.copyDirectory(libertySettingsFolder, installDir);
-            } else {
-                log.info("No custom Liberty configuration files found.");
-            }
-        } else {
-            log.debug("No custom Liberty configuration folder found.");
-        }
     }
 }


### PR DESCRIPTION
Fixes #327 

Liberty settings folder can be specified with <libertySettingsFolder>, and all files will be copied to `{liberty.install.dir}/etc`.

Added tests for successful and failed cases.