### PR TITLE
Avoid running tests twice

### DIFF
--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DevMojo.java
@@ -595,7 +595,7 @@ public class DevMojo extends StartDebugMojoSupport {
 
     private void runTestThread(ThreadPoolExecutor executor, String regexp, File logFile, int messageOccurrences) {
         try {
-            executor.execute(new TestJob(regexp, logFile, messageOccurrences));
+            executor.execute(new TestJob(regexp, logFile, messageOccurrences, executor));
         } catch (RejectedExecutionException e) {
             log.debug("Cannot add thread since max threads reached", e);
         }
@@ -605,21 +605,35 @@ public class DevMojo extends StartDebugMojoSupport {
         private String regexp;
         private File logFile;
         private int messageOccurrences;
+        private ThreadPoolExecutor executor;
 
-        public TestJob(String regexp, File logFile, int messageOccurrences) {
+        public TestJob(String regexp, File logFile, int messageOccurrences, ThreadPoolExecutor executor) {
             this.regexp = regexp;
             this.logFile = logFile;
             this.messageOccurrences = messageOccurrences;
+            this.executor = executor;
         }
 
         @Override
         public void run() {
-            runTests(regexp, logFile, messageOccurrences);
+            runTests(regexp, logFile, messageOccurrences, executor);
         }
     }
 
-    private void runTests(String regexp, File logFile, int messageOccurrences) {
+    private void runTests(String regexp, File logFile, int messageOccurrences, ThreadPoolExecutor executor) {
         if (skipTests) {
+            return;
+        }
+
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            log.debug("Thread interrupted while waiting to start unit tests.", e);
+        }
+
+        // if queue size >= 1, it means a newer test has been queued so we should skip this and let that run instead
+        if (executor.getQueue().size() >= 1) {
+            log.debug("Changes were detected before tests began. Cancelling tests and resubmitting them.");
             return;
         }
 
@@ -631,6 +645,12 @@ public class DevMojo extends StartDebugMojoSupport {
             } catch (MojoExecutionException e) {
                 log.error("Failed to run unit tests", e);
             }    
+        }
+        
+        // if queue size >= 1, it means a newer test has been queued so we should skip this and let that run instead
+        if (executor.getQueue().size() >= 1) {
+            log.info("Changes were detected while tests were running. Restarting tests.");
+            return;
         }
         
         if (!skipITs) {


### PR DESCRIPTION
On Linux, when you save a file with a normal text editor, it appears as if the file is modified twice, which results in the tests getting run twice.  To get around this, wait a short time before starting the tests.  If new tests are queued within this time, cancel the current tests and let the new tests run.