### PR TITLE
Reset WatchKey after processing events

### DIFF
--- a/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DevMojo.java
+++ b/liberty-maven-plugin/src/main/java/net/wasdev/wlp/maven/plugins/server/DevMojo.java
@@ -293,6 +293,10 @@ public class DevMojo extends StartDebugMojoSupport {
                                 debug("messages.log has been changed");
                             }
                         }
+
+                        if (!key.reset()) {
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Solves the issue on Windows where server start hangs when there is an existing logs directory.
